### PR TITLE
Add missing apostrophe in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ After::
     SECRET_KEY = env('SECRET_KEY') # Raises ImproperlyConfigured exception if SECRET_KEY not in os.environ
 
     CACHES = {
-        'default: env.cache(),
+        'default': env.cache(),
         'redis': env.cache('REDIS_URL')
     }
 


### PR DESCRIPTION
The README.rst is missing an apostrophe in one of the config examples and this pull request adds it in.
