### PR TITLE
include a class-level reference to the environment dictionary

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -59,6 +59,7 @@ class Env(object):
             ...
     """
 
+    ENVIRON = os.environ
     NOTSET = NoValue()
     BOOLEAN_TRUE_STRINGS = ('true', 'on', 'ok', 'y', 'yes', '1')
     URL_CLASS = urlparse.ParseResult
@@ -245,7 +246,7 @@ class Env(object):
                     cast = var_info
 
         try:
-            value = os.environ[var]
+            value = self.ENVIRON[var]
         except KeyError:
             if default is self.NOTSET:
                 error_msg = "Set the {0} environment variable".format(var)
@@ -509,8 +510,8 @@ class Env(object):
 
         return config
 
-    @staticmethod
-    def read_env(env_file=None, **overrides):
+    @classmethod
+    def read_env(cls, env_file=None, **overrides):
         """Read a .env file into os.environ.
 
         If not given a path to a dotenv path, does filthy magic stack backtracking
@@ -546,11 +547,11 @@ class Env(object):
                 m3 = re.match(r'\A"(.*)"\Z', val)
                 if m3:
                     val = re.sub(r'\\(.)', r'\1', m3.group(1))
-                os.environ.setdefault(key, text_type(val))
+                cls.ENVIRON.setdefault(key, text_type(val))
 
         # set defaults
         for key, value in overrides.items():
-            os.environ.setdefault(key, value)
+            cls.ENVIRON.setdefault(key, value)
 
 
 class Path(object):

--- a/environ/test.py
+++ b/environ/test.py
@@ -209,7 +209,7 @@ class SubClassTests(EnvTests):
         self.env = MyEnv()
 
     def test_singleton_environ(self):
-        self.assertIs(self.CONFIG, self.env.ENVIRON)
+        self.assertTrue(self.CONFIG is self.env.ENVIRON)
 
 class SchemaEnvTests(BaseTests):
 

--- a/environ/test.py
+++ b/environ/test.py
@@ -48,13 +48,11 @@ class BaseTests(unittest.TestCase):
                     PATH_VAR=cls.PATH)
 
     def setUp(self):
+        Env.ENVIRON = self.generateData()
         self.env = Env()
-        self.environ = self.generateData()
-        self._orig_environ = os.environ
-        os.environ = self.environ
 
     def tearDown(self):
-        os.environ = self._orig_environ
+        Env.ENVIRON = os.environ
 
     def assertTypeAndValue(self, type_, expected, actual):
         self.assertEqual(type_, type(actual))
@@ -197,12 +195,21 @@ class EnvTests(BaseTests):
 class FileEnvTests(EnvTests):
 
     def setUp(self):
+        Env.ENVIRON = {}
         self.env = Env()
-        self._orig_environ = os.environ
-        os.environ = {}
         file_path = Path(__file__, is_file=True)('test_env.txt')
         self.env.read_env(file_path, PATH_VAR=Path(__file__, is_file=True).__root__)
 
+class SubClassTests(EnvTests):
+
+    def setUp(self):
+        self.CONFIG = self.generateData()
+        class MyEnv(Env):
+            ENVIRON = self.CONFIG
+        self.env = MyEnv()
+
+    def test_singleton_environ(self):
+        self.assertIs(self.CONFIG, self.env.ENVIRON)
 
 class SchemaEnvTests(BaseTests):
 
@@ -472,7 +479,11 @@ class PathTests(unittest.TestCase):
 def load_suite():
 
     test_suite = unittest.TestSuite()
-    for case in [EnvTests, FileEnvTests, SchemaEnvTests, PathTests, DatabaseTestSuite, CacheTestSuite, EmailTests]:
+    cases = [
+        EnvTests, FileEnvTests, SubClassTests, SchemaEnvTests, PathTests,
+        DatabaseTestSuite, CacheTestSuite, EmailTests
+    ]
+    for case in cases:
         test_suite.addTest(unittest.makeSuite(case))
     return test_suite
 


### PR DESCRIPTION
Referring to the environment through the class allows easier subclassing and test mocking.