### PR TITLE
Fix docs for dict usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ Supported Types
 - float
 - json
 - list (FOO=a,b,c)
-- dict (BAR=key=val;foo=bar)
+- dict (BAR=key=val,foo=bar)
 - url
 - path (environ.Path)
 - db_url


### PR DESCRIPTION
The docs have a semi colon separator, but if you use that you get a traceback: https://gist.github.com/cmheisel/9ac3346541d3b3c1c8bc