### PR TITLE
Fix 2scoops link and minor typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ There are only classes, Env and Path
     True
 
     >>> open('.myenv', 'a').write('DEBUG=on')
-    >>> environ.Env.read_env('.`myenv') # or env.read_env('.myenv')
+    >>> environ.Env.read_env('.myenv') # or env.read_env('.myenv')
     >>> env('DEBUG')
     True
 
@@ -284,7 +284,7 @@ Credits
 
 .. _12factor: http://www.12factor.net/
 .. _12factor-django: http://www.wellfireinteractive.com/blog/easier-12-factor-django/
-.. _`Two Scoops of Django`: https://django.2scoops.org (book)
+.. _`Two Scoops of Django`: http://twoscoopspress.org/
 
 
 .. _Distribute: http://pypi.python.org/pypi/distribute


### PR DESCRIPTION
- new home of two scoops is http://twoscoopspress.org/