### PR TITLE
redis_cache deprecated in 3.8 and removed in 3.9 in favor of django_redis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,10 +69,10 @@ This is your `settings.py` file before you have installed **django-environ**
             ]
         },
         'redis': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
+            'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': '127.0.0.1:6379:1',
             'OPTIONS': {
-                'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
                 'PASSWORD': 'redis-githubbed-password',
             }
         }
@@ -118,7 +118,7 @@ Create a `.env` file::
     DATABASE_URL=psql://urser:un-githubbedpassword@127.0.0.1:8458/database
     # SQLITE_URL=sqlite:///my-local-sqlite.db
     CACHE_URL=memcache://127.0.0.1:11211,127.0.0.1:11212,127.0.0.1:11213
-    REDIS_URL=rediscache://127.0.0.1:6379:1?client_class=redis_cache.client.DefaultClient&password=redis-un-githubbed-password
+    REDIS_URL=rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=redis-un-githubbed-password
 
 
 How to install

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,10 +58,10 @@ This is your `settings.py` file before you have installed **django-environ**
             ]
         },
         'redis': {
-            'BACKEND': 'redis_cache.cache.RedisCache',
+            'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': '127.0.0.1:6379:1',
             'OPTIONS': {
-                'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
                 'PASSWORD': 'redis-githubbed-password',
             }
         }
@@ -107,7 +107,7 @@ Create a `.env` file::
     DATABASE_URL=psql://urser:un-githubbedpassword@127.0.0.1:8458/database
     # SQLITE_URL=sqlite:///my-local-sqlite.db
     CACHE_URL=memcache://127.0.0.1:11211,127.0.0.1:11212,127.0.0.1:11213
-    REDIS_URL=rediscache://127.0.0.1:6379:1?client_class=redis_cache.client.DefaultClient&password=redis-un-githubbed-password
+    REDIS_URL=rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=redis-un-githubbed-password
 
 
 How to install

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -86,8 +86,8 @@ class Env(object):
         'locmemcache': 'django.core.cache.backends.locmem.LocMemCache',
         'memcache': 'django.core.cache.backends.memcached.MemcachedCache',
         'pymemcache': 'django.core.cache.backends.memcached.PyLibMCCache',
-        'rediscache': 'redis_cache.cache.RedisCache',
-        'redis': 'redis_cache.cache.RedisCache',
+        'rediscache': 'django_redis.cache.RedisCache',
+        'redis': 'django_redis.cache.RedisCache',
     }
     _CACHE_BASE_OPTIONS = ['TIMEOUT', 'KEY_PREFIX', 'VERSION', 'KEY_FUNCTION']
 

--- a/environ/test.py
+++ b/environ/test.py
@@ -13,7 +13,7 @@ class BaseTests(unittest.TestCase):
     MYSQLGIS = 'mysqlgis://user:password@127.0.0.1/some_database'
     SQLITE = 'sqlite:////full/path/to/your/database/file.sqlite'
     MEMCACHE = 'memcache://127.0.0.1:11211'
-    REDIS = 'rediscache://127.0.0.1:6379:1?client_class=redis_cache.client.DefaultClient&password=secret'
+    REDIS = 'rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=secret'
     EMAIL = 'smtps://user@domain.com:password@smtp.example.com:587'
     JSON = dict(one='bar', two=2, three=33.44)
     DICT = dict(foo='bar', test='on')
@@ -167,10 +167,10 @@ class EnvTests(BaseTests):
         self.assertEqual(cache_config['LOCATION'], '127.0.0.1:11211')
 
         redis_config = self.env.cache_url('CACHE_REDIS')
-        self.assertEqual(redis_config['BACKEND'], 'redis_cache.cache.RedisCache')
+        self.assertEqual(redis_config['BACKEND'], 'django_redis.cache.RedisCache')
         self.assertEqual(redis_config['LOCATION'], '127.0.0.1:6379:1')
         self.assertEqual(redis_config['OPTIONS'], {
-            'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             'PASSWORD': 'secret',
         })
 
@@ -378,20 +378,20 @@ class CacheTestSuite(unittest.TestCase):
         self.assertEqual(url['LOCATION'], '')
 
     def test_redis_parsing(self):
-        url = 'rediscache://127.0.0.1:6379:1?client_class=redis_cache.client.DefaultClient&password=secret'
+        url = 'rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=secret'
         url = Env.cache_url_config(url)
 
-        self.assertEqual(url['BACKEND'], 'redis_cache.cache.RedisCache')
+        self.assertEqual(url['BACKEND'], 'django_redis.cache.RedisCache')
         self.assertEqual(url['LOCATION'], '127.0.0.1:6379:1')
         self.assertEqual(url['OPTIONS'], {
-            'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             'PASSWORD': 'secret',
         })
 
     def test_redis_socket_parsing(self):
         url = 'rediscache:///path/to/socket:1'
         url = Env.cache_url_config(url)
-        self.assertEqual(url['BACKEND'], 'redis_cache.cache.RedisCache')
+        self.assertEqual(url['BACKEND'], 'django_redis.cache.RedisCache')
         self.assertEqual(url['LOCATION'], 'unix:/path/to/socket:1')
 
     def test_options_parsing(self):
@@ -408,7 +408,7 @@ class CacheTestSuite(unittest.TestCase):
 
     def test_custom_backend(self):
         url = 'memcache://127.0.0.1:5400?foo=option&bars=9001'
-        backend = 'redis_cache.cache.RedisCache'
+        backend = 'django_redis.cache.RedisCache'
         url = Env.cache_url_config(url, backend)
 
         self.assertEqual(url['BACKEND'], backend)

--- a/environ/test_env.txt
+++ b/environ/test_env.txt
@@ -3,7 +3,7 @@ BOOL_FALSE_VAR2=False
 DATABASE_MYSQL_URL=mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true
 DATABASE_MYSQL_GIS_URL=mysqlgis://user:password@127.0.0.1/some_database
 CACHE_URL=memcache://127.0.0.1:11211
-CACHE_REDIS=rediscache://127.0.0.1:6379:1?client_class=redis_cache.client.DefaultClient&password=secret
+CACHE_REDIS=rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=secret
 EMAIL_URL=smtps://user@domain.com:password@smtp.example.com:587
 URL_VAR=http://www.google.com/
 PATH_VAR=/home/dev


### PR DESCRIPTION
This is a breaking change, so major revision number should be bumped but did not include that in here.