### PR TITLE
remove .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-source = environ/
-omit = environ/test.py


### PR DESCRIPTION
Removing .coveragerc to restore coveralls.io service
