### PR TITLE
added a resolve_proxies=False option and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,28 @@ Supported Types
     - LocMem mail: memorymail://
     - Dummy mail: dummymail://
 
+Proxied Values
+==============
+
+An environ value or default can reference another environ value by referring to it with a $ sign.  For example:
+
+.. code-block:: python
+
+    PROXIED_VAL = 'hello'
+    TEST_VAL ='$PROXIED_VAL'
+    environ('TEST_VAL') == 'hello
+    environ('UNKNOWN_VAL', default='$PROXIED_VAL') == 'hello'
+
+Proxy values are resolved by default.  To turn off resolving proxy values
+pass ``resolve_proxies=False`` to ``environ``, ``environ.str``, or ``environ.unicode``.
+
+Ex:  ``environ('DJANGO_SECRET_KEY', '$1233FJSIFWR44', resolve_proxies=False)``
+
+If you get an infinite recursion when using environ most likely you have an unresolved and perhaps
+unintentional proxy value in an environ string.
+For example ``environ('DJANGO_SECRET_KEY', '$1233FJSIFWR44')`` will cause an infinite
+recursion unless you add ``resolve_proxies=False``.
+
 Tips
 ====
 

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -120,22 +120,24 @@ class Env(object):
     def __init__(self, **scheme):
         self.scheme = scheme
 
-    def __call__(self, var, cast=None, default=NOTSET, parse_default=False):
-        return self.get_value(var, cast=cast, default=default, parse_default=parse_default)
+    def __call__(self, var, cast=None, default=NOTSET, parse_default=False, resolve_proxies=True):
+        return self.get_value(var, cast=cast, default=default, parse_default=parse_default,
+                              resolve_proxies=resolve_proxies)
 
     # Shortcuts
 
-    def str(self, var, default=NOTSET):
+    def str(self, var, default=NOTSET, resolve_proxies=True):
         """
         :rtype: str
         """
-        return self.get_value(var, default=default)
+        return self.get_value(var, default=default, resolve_proxies=resolve_proxies)
+    
 
-    def unicode(self, var, default=NOTSET):
+    def unicode(self, var, default=NOTSET, resolve_proxies=True):
         """Helper for python2
         :rtype: unicode
         """
-        return self.get_value(var, cast=str, default=default)
+        return self.get_value(var, cast=str, default=default, resolve_proxies=resolve_proxies)
 
     def bool(self, var, default=NOTSET):
         """
@@ -222,13 +224,14 @@ class Env(object):
         """
         return Path(self.get_value(var, default=default), **kwargs)
 
-    def get_value(self, var, cast=None, default=NOTSET, parse_default=False):
+    def get_value(self, var, cast=None, default=NOTSET, parse_default=False, resolve_proxies=True):
         """Return value for given environment variable.
 
         :param var: Name of variable.
         :param cast: Type to cast return value as.
         :param default: If var not present in environ, return this instead.
         :param parse_default: force to parse default..
+        :param resolve_proxies: resolve proxied values, ie values like $MYVAR
 
         :returns: Value from environment or default (if set)
         """
@@ -268,7 +271,7 @@ class Env(object):
             value = default
 
         # Resolve any proxied values
-        if hasattr(value, 'startswith') and value.startswith('$'):
+        if resolve_proxies and hasattr(value, 'startswith') and value.startswith('$'):
             value = value.lstrip('$')
             value = self.get_value(value, cast=cast, default=default)
 

--- a/environ/test.py
+++ b/environ/test.py
@@ -108,6 +108,11 @@ class EnvTests(BaseTests):
 
     def test_proxied_value(self):
         self.assertTypeAndValue(str, 'bar', self.env('PROXIED_VAR'))
+        
+    def test_disabling_proxies(self):
+        self.assertTypeAndValue(str, '$STR_VAR', self.env('PROXIED_VAR', resolve_proxies=False))
+        self.assertTypeAndValue(str, '$STR_VAR', self.str('PROXIED_VAR', resolve_proxies=False))
+        self.assertTypeAndValue(str, '$STR_VAR', self.unicode('PROXIED_VAR', resolve_proxies=False))
 
     def test_int_list(self):
         self.assertTypeAndValue(list, [42, 33], self.env('INT_LIST', cast=[int]))

--- a/environ/test.py
+++ b/environ/test.py
@@ -111,8 +111,8 @@ class EnvTests(BaseTests):
         
     def test_disabling_proxies(self):
         self.assertTypeAndValue(str, '$STR_VAR', self.env('PROXIED_VAR', resolve_proxies=False))
-        self.assertTypeAndValue(str, '$STR_VAR', self.str('PROXIED_VAR', resolve_proxies=False))
-        self.assertTypeAndValue(str, '$STR_VAR', self.unicode('PROXIED_VAR', resolve_proxies=False))
+        self.assertTypeAndValue(str, '$STR_VAR', self.env.str('PROXIED_VAR', resolve_proxies=False))
+        self.assertTypeAndValue(str, '$STR_VAR', self.env.unicode('PROXIED_VAR', resolve_proxies=False))
 
     def test_int_list(self):
         self.assertTypeAndValue(list, [42, 33], self.env('INT_LIST', cast=[int]))


### PR DESCRIPTION
passing this option to environ(), environ.str(), or environ.unicode() will stop the parsing of proxied values and resolve issues like https://github.com/joke2k/django-environ/issues/60.  Also added documentation on proxied values in general.
