### PR TITLE
Fix oracle port handling

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -388,8 +388,12 @@ class Env(object):
             config['NAME'] = config['HOST']
             config['HOST'] = ''
 
-        if url.scheme == 'oracle' and not config['PORT']:
-            del(config['PORT']) # Django oracle/base.py strips port and fails on None
+        if url.scheme == 'oracle':
+            # Django oracle/base.py strips port and fails on non-string value
+            if not config['PORT']:
+                del(config['PORT'])
+            else:
+                config['PORT'] = str(config['PORT'])
 
         if url.query:
             config_options = {}

--- a/environ/test.py
+++ b/environ/test.py
@@ -187,7 +187,7 @@ class EnvTests(BaseTests):
         self.assertEqual(oracle_config['HOST'], 'host')
         self.assertEqual(oracle_config['USER'], 'user')
         self.assertEqual(oracle_config['PASSWORD'], 'password')
-        self.assertEqual(oracle_config['PORT'], 1521)
+        self.assertEqual(oracle_config['PORT'], '1521')
 
         sqlite_config = self.env.db('DATABASE_SQLITE_URL')
         self.assertEqual(sqlite_config['ENGINE'], 'django.db.backends.sqlite3')


### PR DESCRIPTION
The Django Oracle drive requires the port argument to be a string (since it calls `.strip()` on it)
