### PR TITLE
Accept python 3.6 path-like objects for read_env

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -18,6 +18,13 @@ except ImportError:
 from six.moves import urllib
 from six import string_types
 
+
+try:
+    from os import PathLike
+    Openable = (string_types, PathLike)
+except ImportError:
+    Openable = (string_types,)
+
 logger = logging.getLogger(__name__)
 
 
@@ -609,7 +616,7 @@ class Env(object):
                 return
 
         try:
-            with open(env_file) if isinstance(env_file, string_types) else env_file as f:
+            with open(env_file) if isinstance(env_file, Openable) else env_file as f:
                 content = f.read()
         except IOError:
             warnings.warn(

--- a/environ/test.py
+++ b/environ/test.py
@@ -241,6 +241,40 @@ class FileEnvTests(EnvTests):
         file_path = Path(__file__, is_file=True)('test_env.txt')
         self.env.read_env(file_path, PATH_VAR=Path(__file__, is_file=True).__root__)
 
+    def test_read_env_path_like(self):
+
+        # No pathlib on Python < 3.4
+        try:
+            import pathlib
+        except ImportError:
+            return
+
+        path_like = (pathlib.Path(__file__).parent / 'test_env_pathlib.txt')
+        self.assertFalse(path_like.exists())
+        env_key = 'JALSDKFJ'
+        env_val = '98198165464984984'
+        env_str = env_key + '=' + env_val
+
+        def cleanup():
+            try:
+                path_like.unlink()
+            except:
+                pass
+
+        self.addCleanup(cleanup)
+
+        # open() doesn't take path-like on Python < 3.6
+        try:
+            with open(path_like, 'w') as f:
+                f.write(env_str + '\n')
+        except TypeError:
+            return
+
+        self.assertTrue(path_like.exists(), msg=path_like)
+        self.env.read_env(path_like)
+        self.assertIn(env_key, self.env.ENVIRON)
+        self.assertEqual(self.env.ENVIRON[env_key], env_val)
+
 class SubClassTests(EnvTests):
 
     def setUp(self):


### PR DESCRIPTION
I just went ahead and implemented what I talked about in #106.

The test is kind of icky, but it seems to get the job done.