### PR TITLE
Update DB selection syntax for Redis cache urls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ This is your `settings.py` file before you have installed **django-environ**
         },
         'redis': {
             'BACKEND': 'django_redis.cache.RedisCache',
-            'LOCATION': '127.0.0.1:6379:1',
+            'LOCATION': '127.0.0.1:6379/1',
             'OPTIONS': {
                 'CLIENT_CLASS': 'django_redis.client.DefaultClient',
                 'PASSWORD': 'redis-githubbed-password',
@@ -116,7 +116,7 @@ Create a ``.env`` file:
     DATABASE_URL=psql://urser:un-githubbedpassword@127.0.0.1:8458/database
     # SQLITE_URL=sqlite:///my-local-sqlite.db
     CACHE_URL=memcache://127.0.0.1:11211,127.0.0.1:11212,127.0.0.1:11213
-    REDIS_URL=rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=redis-un-githubbed-password
+    REDIS_URL=rediscache://127.0.0.1:6379/1?client_class=django_redis.client.DefaultClient&password=redis-un-githubbed-password
 
 
 How to install

--- a/environ/test.py
+++ b/environ/test.py
@@ -19,7 +19,7 @@ class BaseTests(unittest.TestCase):
     ORACLE_TNS = 'oracle://user:password@sid/'
     ORACLE = 'oracle://user:password@host:1521/sid'
     MEMCACHE = 'memcache://127.0.0.1:11211'
-    REDIS = 'rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=secret'
+    REDIS = 'rediscache://127.0.0.1:6379/1?client_class=django_redis.client.DefaultClient&password=secret'
     EMAIL = 'smtps://user@domain.com:password@smtp.example.com:587'
     JSON = dict(one='bar', two=2, three=33.44)
     DICT = dict(foo='bar', test='on')
@@ -208,7 +208,7 @@ class EnvTests(BaseTests):
 
         redis_config = self.env.cache_url('CACHE_REDIS')
         self.assertEqual(redis_config['BACKEND'], 'django_redis.cache.RedisCache')
-        self.assertEqual(redis_config['LOCATION'], 'redis://127.0.0.1:6379:1')
+        self.assertEqual(redis_config['LOCATION'], 'redis://127.0.0.1:6379/1')
         self.assertEqual(redis_config['OPTIONS'], {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             'PASSWORD': 'secret',
@@ -439,11 +439,11 @@ class CacheTestSuite(unittest.TestCase):
         self.assertEqual(url['LOCATION'], '')
 
     def test_redis_parsing(self):
-        url = 'rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=secret'
+        url = 'rediscache://127.0.0.1:6379/1?client_class=django_redis.client.DefaultClient&password=secret'
         url = Env.cache_url_config(url)
 
         self.assertEqual(url['BACKEND'], REDIS_DRIVER)
-        self.assertEqual(url['LOCATION'], 'redis://127.0.0.1:6379:1')
+        self.assertEqual(url['LOCATION'], 'redis://127.0.0.1:6379/1')
         self.assertEqual(url['OPTIONS'], {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             'PASSWORD': 'secret',

--- a/environ/test_env.txt
+++ b/environ/test_env.txt
@@ -3,7 +3,7 @@ BOOL_FALSE_VAR2=False
 DATABASE_MYSQL_URL=mysql://bea6eb0:69772142@us-cdbr-east.cleardb.com/heroku_97681?reconnect=true
 DATABASE_MYSQL_GIS_URL=mysqlgis://user:password@127.0.0.1/some_database
 CACHE_URL=memcache://127.0.0.1:11211
-CACHE_REDIS=rediscache://127.0.0.1:6379:1?client_class=django_redis.client.DefaultClient&password=secret
+CACHE_REDIS=rediscache://127.0.0.1:6379/1?client_class=django_redis.client.DefaultClient&password=secret
 EMAIL_URL=smtps://user@domain.com:password@smtp.example.com:587
 URL_VAR=http://www.google.com/
 PATH_VAR=/home/dev


### PR DESCRIPTION
Since version 0.4.1, it is now possible to correctly configure a Redis server as cache system for Django application using django-environ. Specifically, it is now possible to select the DB to use.

As described in [django-redis documentation](https://niwinz.github.io/django-redis/latest/), the correct value for Redis LOCATION Url is `redis://127.0.0.1:6379/1` for DB1, `redis://127.0.0.1:6379/6` for DB6, etc.

In my tests, the syntax `redis://127.0.0.1:6379:1` didn't work. It writes values to DB 0 by default, and in some case, raises an exception:

```
  [...]
  File "C:\Users\Antoine\.virtualenvs\xxx\lib\site-packages\django_redis\pool.py", line 114, in get_connection_pool
    pool = self.pool_cls.from_url(**cp_params)
  File "C:\Users\Antoine\.virtualenvs\xxx\lib\site-packages\redis\connection.py", line 813, in from_url
    'port': int(url.port or 6379),
  File "c:\python35-x64\Lib\urllib\parse.py", line 159, in port
    port = int(port, 10)
ValueError: invalid literal for int() with base 10: '6379:4'
```

This PR may fix the issue and help users to use the right syntax when declaring a Redis cache.