### PR TITLE
Add scheme for pyodbc for use with django-pyodbc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,7 @@ Supported Types
     -  SQLITE: sqlite://
     -  SQLITE with SPATIALITE for GeoDjango: spatialite://
     -  Oracle: oracle://
+    -  PyODBC: pyodbc://
     -  Redshift: redshift://
     -  LDAP: ldap://
 - cache_url

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -78,6 +78,7 @@ class Env(object):
         'mysql2': 'django.db.backends.mysql',
         'mysqlgis': 'django.contrib.gis.db.backends.mysql',
         'oracle': 'django.db.backends.oracle',
+        'pyodbc': 'sql_server.pyodbc',
         'redshift': 'django_redshift_backend',
         'spatialite': 'django.contrib.gis.db.backends.spatialite',
         'sqlite': 'django.db.backends.sqlite3',


### PR DESCRIPTION
This will also support using  and django-pyodbc-azure for databases.

We have a secondary database running SQL Server, and this allows for connecting via the Django pyodbc stack.

Thank you for your efforts!