### PR TITLE
Add support for environment names with export prefix

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -621,7 +621,7 @@ class Env(object):
         logger.debug('Read environment variables from: {0}'.format(env_file))
 
         for line in content.splitlines():
-            m1 = re.match(r'\A([A-Za-z_0-9]+)=(.*)\Z', line)
+            m1 = re.match(r'\A(?:export )?([A-Za-z_0-9]+)=(.*)\Z', line)
             if m1:
                 key, val = m1.group(1), m1.group(2)
                 m2 = re.match(r"\A'(.*)'\Z", val)

--- a/environ/test.py
+++ b/environ/test.py
@@ -25,6 +25,7 @@ class BaseTests(unittest.TestCase):
     JSON = dict(one='bar', two=2, three=33.44)
     DICT = dict(foo='bar', test='on')
     PATH = '/home/dev'
+    EXPORTED = 'exported var'
 
     @classmethod
     def generateData(cls):
@@ -56,7 +57,8 @@ class BaseTests(unittest.TestCase):
                     EMAIL_URL=cls.EMAIL,
                     URL_VAR=cls.URL,
                     JSON_VAR=json.dumps(cls.JSON),
-                    PATH_VAR=cls.PATH)
+                    PATH_VAR=cls.PATH,
+                    EXPORTED_VAR=cls.EXPORTED)
 
     def setUp(self):
         self._old_environ = os.environ
@@ -240,6 +242,9 @@ class EnvTests(BaseTests):
     def test_path(self):
         root = self.env.path('PATH_VAR')
         self.assertTypeAndValue(Path, Path(self.PATH), root)
+
+    def test_exported(self):
+        self.assertEqual(self.EXPORTED, self.env('EXPORTED_VAR'))
 
 
 class FileEnvTests(EnvTests):

--- a/environ/test_env.txt
+++ b/environ/test_env.txt
@@ -28,3 +28,4 @@ INT_TUPLE=(42,33)
 DATABASE_ORACLE_TNS_URL=oracle://user:password@sid
 DATABASE_ORACLE_URL=oracle://user:password@host:1521/sid
 DATABASE_REDSHIFT_URL=redshift://user:password@examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev
+export EXPORTED_VAR="exported var"


### PR DESCRIPTION
Useful if you source the `.env` file directly from bash or equivalent.