### PR TITLE
Fix environment reading

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -122,6 +122,9 @@ class Env(object):
 
     def __init__(self, **scheme):
         self.scheme = scheme
+        # Make sure environment is read correctly
+        if self.ENVIRON == {}:
+            self.ENVIRON = os.environ
 
     def __call__(self, var, cast=None, default=NOTSET, parse_default=False):
         return self.get_value(var, cast=cast, default=default, parse_default=parse_default)
@@ -600,6 +603,8 @@ class Env(object):
 
         https://gist.github.com/bennylope/2999704
         """
+        if cls.ENVIRON == {}:
+            cls.ENVIRON = os.environ
         if env_file is None:
             frame = sys._getframe()
             env_file = os.path.join(os.path.dirname(frame.f_back.f_code.co_filename), '.env')


### PR DESCRIPTION
Make sure that `Env.ENVIRON` is an actual `environ` object and not an empty dictionary.

Which can happen in sometimes because of this in stdlib: https://github.com/python/cpython/blob/e613e6add5f07ff6aad5802924596b631b707d2a/Lib/os.py#L532 — if `ENVIRON = os.environ` happens before `os` module is properly initialized it might screw up everything, like this:
```
>>> os.environ
environ({'DJANGO_SETTINGS_MODULE': 'config.settings', '_': '/usr/local/bin/python', 'BASE_DIR': '/app/src', 'SYNC_WEATHER': 'off', 'TERM': 'screen-256color', 'PWD': '/app', 'CACHE_URL': 'redis://redis:6379/1', 'PYTHONBUFFERED': '1', 'DATABASE_URL': 'psql://postgres:@db:5432/postgres', 'SHLVL': '1', 'HOME': '/root', 'PYTHONPATH': '`pwd`/src', 'HOSTNAME': 'a7101ffce4a0', 'SECRET_KEY': 'notsecret', 'PYTHON_VERSION': '3.5.2', 'LANG': 'C.UTF-8', 'CELERY_REDIS_URI': 'redis://redis:6379/0', 'PATH': '/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'DEBUG': 'on', 'PYTHON_PIP_VERSION': '9.0.1'})
>>> environ.Env.ENVIRON
{}
```

I haven't been able in pinpointing the exact reason why it happens on some systems but not the others (snippet above was made in standard `python` docker container) but it's trivial to fix. We just need to assign `os.environ` again after initial initialization (if it was done correctly first time round, it should be exactly the same object and no harm done).