### PR TITLE
Use pkgutil to detect installed packages, import may have side effects

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -5,6 +5,7 @@ variables to configure your Django application.
 import json
 import logging
 import os
+import pkgutil
 import re
 import sys
 import warnings
@@ -38,11 +39,8 @@ DJANGO_REDIS_DRIVER = 'django_redis.cache.RedisCache'
 DJANGO_REDIS_CACHE_DRIVER = 'redis_cache.RedisCache'
 
 REDIS_DRIVER = DJANGO_REDIS_DRIVER
-try:
-    import redis_cache
+if pkgutil.find_loader('redis_cache'):
     REDIS_DRIVER = DJANGO_REDIS_CACHE_DRIVER
-except:
-    pass
 
 
 class NoValue(object):

--- a/environ/test.py
+++ b/environ/test.py
@@ -217,7 +217,7 @@ class EnvTests(BaseTests):
         self.assertEqual(cache_config['LOCATION'], '127.0.0.1:11211')
 
         redis_config = self.env.cache_url('CACHE_REDIS')
-        self.assertEqual(redis_config['BACKEND'], 'django_redis.cache.RedisCache')
+        self.assertEqual(redis_config['BACKEND'], 'redis_cache.RedisCache')
         self.assertEqual(redis_config['LOCATION'], 'redis://127.0.0.1:6379/1')
         self.assertEqual(redis_config['OPTIONS'], {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
@@ -462,7 +462,7 @@ class CacheTestSuite(unittest.TestCase):
     def test_redis_socket_parsing(self):
         url = 'rediscache:///path/to/socket:1'
         url = Env.cache_url_config(url)
-        self.assertEqual(url['BACKEND'], 'django_redis.cache.RedisCache')
+        self.assertEqual(url['BACKEND'], 'redis_cache.RedisCache')
         self.assertEqual(url['LOCATION'], 'unix:///path/to/socket:1')
 
     def test_redis_with_password_parsing(self):

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ author = 'joke2k'
 description = "Django-environ allows you to utilize 12factor inspired environment " \
               "variables to configure your Django application."
 install_requires = ['django', 'six']
+tests_require = ['django-redis-cache']
 
 setup(name='django-environ',
       version=version,
@@ -51,4 +52,5 @@ setup(name='django-environ',
       test_suite='environ.test.load_suite',
       zip_safe=False,
       install_requires=install_requires,
+      tests_require=tests_require,
       )


### PR DESCRIPTION
As a fix for #130 i propose using `pkgutil` to detect `redis_cache` instead of trying to import.