### PR TITLE
Make Env.read_env()'s "overrides" argument actually override variables

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -659,7 +659,7 @@ class Env(object):
                     val = re.sub(r'\\(.)', r'\1', m3.group(1))
                 cls.ENVIRON.setdefault(key, str(val))
 
-        # set defaults
+        # set overrides
         for key, value in overrides.items():
             cls.ENVIRON[key] = value
 

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -661,7 +661,7 @@ class Env(object):
 
         # set defaults
         for key, value in overrides.items():
-            cls.ENVIRON.setdefault(key, value)
+            cls.ENVIRON[key] = value
 
 
 class Path(object):

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -614,6 +614,12 @@ class Env(object):
     def read_env(cls, env_file=None, **overrides):
         """Read a .env file into os.environ.
 
+        Existing environment variables take precedent and are NOT overwritten
+        by the file content.
+
+        Key/value pairs given as `overrides` DO overwrite existing variables.
+        Keep in mind, that variable names are case sensitive, when overriding!
+
         If not given a path to a dotenv path, does filthy magic stack backtracking
         to find manage.py and then find the dotenv.
 

--- a/environ/test.py
+++ b/environ/test.py
@@ -282,8 +282,26 @@ class FileEnvTests(EnvTests):
         super(FileEnvTests, self).setUp()
         Env.ENVIRON = {}
         self.env = Env()
-        file_path = Path(__file__, is_file=True)('test_env.txt')
-        self.env.read_env(file_path, PATH_VAR=Path(__file__, is_file=True).__root__)
+        self.file_path = Path(__file__, is_file=True)('test_env.txt')
+        self.env.read_env(self.file_path)
+
+    def test_read_env_overrides(self):
+        # overrides given as kwargs to read_env() override any existing
+        # variables including those just read from the file
+        self.env.read_env(
+            self.file_path,
+            STR_VAR='foo',
+            INT_VAR='82',
+        )
+        self.assertTypeAndValue(str, 'foo', self.env('STR_VAR'))
+        self.assertTypeAndValue(str, 'foo', self.env.str('STR_VAR'))
+
+        self.assertTypeAndValue(str, '82', self.env('INT_VAR'))
+        self.assertTypeAndValue(int, 82, self.env.int('INT_VAR'))
+
+        with self.assertRaises(ImproperlyConfigured):
+            self.env('str_var')
+
 
 class SubClassTests(EnvTests):
 


### PR DESCRIPTION
Proposed fix and clarification in docstring for #103. As mentioned in the issue I am not 100% clear on what the intention with `overrides` was, but as it is called "override" I thought it maybe should _override_ variables ;)