### PR TITLE
Add __contains__

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -126,6 +126,9 @@ class Env(object):
     def __call__(self, var, cast=None, default=NOTSET, parse_default=False):
         return self.get_value(var, cast=cast, default=default, parse_default=parse_default)
 
+    def __contains__(self, var):
+        return var in self.ENVIRON
+
     # Shortcuts
 
     def str(self, var, default=NOTSET):

--- a/environ/test.py
+++ b/environ/test.py
@@ -79,6 +79,11 @@ class EnvTests(BaseTests):
     def test_not_present_without_default(self):
         self.assertRaises(ImproperlyConfigured, self.env, 'not_present')
 
+    def test_contains(self):
+        self.assertTrue('STR_VAR' in self.env)
+        self.assertTrue('EMPTY_LIST' in self.env)
+        self.assertFalse('I_AM_NOT_A_VAR' in self.env)
+
     def test_str(self):
         self.assertTypeAndValue(str, 'bar', self.env('STR_VAR'))
         self.assertTypeAndValue(str, 'bar', self.env.str('STR_VAR'))


### PR DESCRIPTION
Allows using `"VARNAME" in env` syntax, which is useful to enable special behavior if a variable is not defined, without worrying about the type of the variable.

Currently, this ignores the schema, which seems more intuitive to me (ie. true means it's explicitly defined somewhere). 