### PR TITLE
Removed proxy variable feature. (#60)

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -276,11 +276,6 @@ class Env(object):
 
             value = default
 
-        # Resolve any proxied values
-        if hasattr(value, 'startswith') and value.startswith('$'):
-            value = value.lstrip('$')
-            value = self.get_value(value, cast=cast, default=default)
-
         if value != default or (parse_default and value):
             value = self.parse_value(value, cast)
 

--- a/environ/test.py
+++ b/environ/test.py
@@ -114,7 +114,7 @@ class EnvTests(BaseTests):
         self.assertTypeAndValue(bool, False, self.env.bool('BOOL_FALSE_VAR'))
 
     def test_proxied_value(self):
-        self.assertTypeAndValue(str, 'bar', self.env('PROXIED_VAR'))
+        self.assertTypeAndValue(str, '$STR_VAR', self.env('PROXIED_VAR'))
 
     def test_int_list(self):
         self.assertTypeAndValue(list, [42, 33], self.env('INT_LIST', cast=[int]))


### PR DESCRIPTION
Expanding variables automatically on a read is an anti-pattern.
Variable expansion by the shell should only be done when the
value is inserted into the environment, but the vlaue should be
treated as opaque data.  Any processing or interpretation of the
variable should be done by the appliaction, not by the access
method.