### PR TITLE
Feature/bytes casting

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -146,6 +146,12 @@ class Env(object):
         """
         return self.get_value(var, cast=str, default=default)
 
+    def bytes(self, var, default=NOTSET, encoding='utf8'):
+        """
+        :rtype: bytes
+        """
+        return self.get_value(var, cast=str).encode(encoding)
+
     def bool(self, var, default=NOTSET):
         """
         :rtype: bool

--- a/environ/test.py
+++ b/environ/test.py
@@ -88,6 +88,9 @@ class EnvTests(BaseTests):
         self.assertTypeAndValue(str, 'bar', self.env('STR_VAR'))
         self.assertTypeAndValue(str, 'bar', self.env.str('STR_VAR'))
 
+    def test_bytes(self):
+        self.assertTypeAndValue(bytes, b'bar', self.env.bytes('STR_VAR'))
+
     def test_int(self):
         self.assertTypeAndValue(int, 42, self.env('INT_VAR', cast=int))
         self.assertTypeAndValue(int, 42, self.env.int('INT_VAR'))


### PR DESCRIPTION
Resolves #162 

Adds a `env.bytes` method, I'm unsure how to support `env(var, cast=bytes)`