### PR TITLE
Fix db_url_config for custom engine

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -415,7 +415,7 @@ class Env(object):
 
         if engine:
             config['ENGINE'] = engine
-        if url.scheme in Env.DB_SCHEMES:
+        elif url.scheme in Env.DB_SCHEMES:
             config['ENGINE'] = Env.DB_SCHEMES[url.scheme]
 
         if not config.get('ENGINE', False):

--- a/environ/test.py
+++ b/environ/test.py
@@ -215,6 +215,10 @@ class EnvTests(BaseTests):
         self.assertEqual(sqlite_config['ENGINE'], 'django.db.backends.sqlite3')
         self.assertEqual(sqlite_config['NAME'], '/full/path/to/your/database/file.sqlite')
 
+        custom_engine_config = self.env.db(engine='my.engine')
+        self.assertEqual(custom_engine_config['ENGINE'], 'my.engine')
+
+
     def test_cache_url_value(self):
 
         cache_config = self.env.cache_url()

--- a/environ/test.py
+++ b/environ/test.py
@@ -381,6 +381,17 @@ class DatabaseTestSuite(unittest.TestCase):
         self.assertEqual(url['USER'], 'cn=admin,dc=nodomain,dc=org')
         self.assertEqual(url['PASSWORD'], 'some_secret_password')
 
+    def test_database_accept_engine(self):
+        url = 'postgres://user:pass@localhost:5432/DatabaseName'
+        url = Env.db_url_config(url, engine='my.engine')
+
+        self.assertEqual(url['ENGINE'], 'my.engine')
+        self.assertEqual(url['NAME'], 'DatabaseName')
+        self.assertEqual(url['HOST'], 'localhost')
+        self.assertEqual(url['USER'], 'user')
+        self.assertEqual(url['PASSWORD'], 'pass')
+        self.assertEqual(url['PORT'], 5432)
+
 
 class CacheTestSuite(unittest.TestCase):
 


### PR DESCRIPTION
Without this fix, db_url_config will keep using Env.DB_SCHEMES engines. 

So, for PostgreSQL, engine would be `django.db.backends.postgresql_psycopg2` even if I ask for `engine = django.db.backends.postgresql`

Also, another suggestion (not included in this PR) would be upgrading to `djangodb.backends.postgresql` instead of `postgresql_psycopg2` , as Django sinalized in [1.9 release notes](https://docs.djangoproject.com/en/2.0/releases/1.9/#database-backends).