### PR TITLE
Warn about ignored netloc component in SQLite URLs

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -375,10 +375,14 @@ class Env(object):
         path = url.path[1:]
         path = urllib.parse.unquote_plus(path.split('?', 2)[0])
 
-        # if we are using sqlite and we have no path, then assume we
-        # want an in-memory database (this is the behaviour of sqlalchemy)
-        if url.scheme == 'sqlite' and path == '':
-            path = ':memory:'
+        if url.scheme == 'sqlite':
+            if path == '':
+                # if we are using sqlite and we have no path, then assume we
+                # want an in-memory database (this is the behaviour of  sqlalchemy)
+                path = ':memory:'
+            if url.netloc:
+                warnings.warn(
+                    'SQLite URL contains host component %r, it will be ignored' % url.netloc, stacklevel=3)
         if url.scheme == 'ldap':
             path = '{scheme}://{hostname}'.format(scheme=url.scheme, hostname=url.hostname)
             if url.port:

--- a/environ/test.py
+++ b/environ/test.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 import unittest
+import warnings
 
 from django.core.exceptions import ImproperlyConfigured
 
@@ -358,6 +359,15 @@ class DatabaseTestSuite(unittest.TestCase):
 
         self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
         self.assertEqual(url['NAME'], ':memory:')
+        
+    def test_memory_sqlite_url_warns_about_netloc(self):
+        url = 'sqlite://missing-slash-path'
+        with warnings.catch_warnings(record=True) as w:
+            url = Env.db_url_config(url)
+            self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
+            self.assertEqual(url['NAME'], ':memory:')
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, UserWarning))
 
     def test_database_options_parsing(self):
         url = 'postgres://user:pass@host:1234/dbname?conn_max_age=600'


### PR DESCRIPTION
I got bitten by an incorrect number of slashes in SQLite database, which resulted in the filename being treated as netloc and the database being created in-memory for every run. Given that netlocs don't mean much for SQLite anyway, I figured it could generate a warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joke2k/django-environ/171)
<!-- Reviewable:end -->
