### PR TITLE
Make `environ.Path` a `PathLike` object

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -753,6 +753,9 @@ class Path(object):
 
     def __getitem__(self, *args, **kwargs):
         return self.__str__().__getitem__(*args, **kwargs)
+    
+    def __fspath__(self):
+        return self.__str__()
 
     def rfind(self, *args, **kwargs):
         return self.__str__().rfind(*args, **kwargs)

--- a/environ/test.py
+++ b/environ/test.py
@@ -665,6 +665,7 @@ class PathTests(unittest.TestCase):
         self.assertEqual(Path('/home/foo/').rfind('/'), str(Path('/home/foo')).rfind('/'))
         self.assertEqual(Path('/home/foo/').find('/home'), str(Path('/home/foo/')).find('/home'))
         self.assertEqual(Path('/home/foo/')[1], str(Path('/home/foo/'))[1])
+        self.assertEqual(Path('/home/foo/').__fspath__(), str(Path('/home/foo/')))
 
         self.assertEqual(~Path('/home'), Path('/'))
         self.assertEqual(Path('/') + 'home', Path('/home'))


### PR DESCRIPTION
Adding the `__fspath__` method makes the std lib of Python 3.6 recognize `Path` objects as '[PathLike](https://docs.python.org/3/library/os.html#os.PathLike)'. This way, `Path` objects can be used with functions from `os.path`, such as `makedirs`