### PR TITLE
Remove install django install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ version = '0.4.4'
 author = 'joke2k'
 description = "Django-environ allows you to utilize 12factor inspired environment " \
               "variables to configure your Django application."
-install_requires = ['django', 'six']
+install_requires = ['six']
 
 setup(name='django-environ',
       version=version,
@@ -49,6 +49,7 @@ setup(name='django-environ',
       platforms=["any"],
       include_package_data=True,
       test_suite='environ.test.load_suite',
+      tests_require=['django'],
       zip_safe=False,
       install_requires=install_requires,
       )


### PR DESCRIPTION
This might be a useful package for those who don't use django or aren't on their current project. There is no need for django to be an install requirement when it's only used in tests.