### PR TITLE
Add option to overwrite existing environment variables in read_env

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -37,7 +37,7 @@ def _cast_urlstr(v):
     return unquote_plus(v) if isinstance(v, str) else v
 
 def _make_setenv(envval, overwrite=False):
-    """ Return lambda to set environUse setdefault unless overwrite is specified """
+    """ Return lambda to set environ. Use setdefault unless overwrite is specified """
     if overwrite:
         return lambda k,v: envval.update({k: str(v)})
     else:


### PR DESCRIPTION
This PR addresses issue #103.
I've had this issue with the uwsgi touch-reload command. It won't pick up updates to .env files.

In some use cases, the .env file should be the master, so an overwrite=True option will resolve the issue in this case.

- All tests pass
- Should be no performance penalty for current use (other than an additional function call)
- Minor performance in overwrite use due to temp dict.

The temp dict was needed since there is no dict.set(k,v) method. The lambda can't do dict[k] = v.
