### PR TITLE
Use default option in Env.bytes()

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -146,7 +146,7 @@ class Env(object):
         """
         :rtype: bytes
         """
-        return self.get_value(var, cast=str).encode(encoding)
+        return self.get_value(var, cast=str, default=default).encode(encoding)
 
     def bool(self, var, default=NOTSET):
         """


### PR DESCRIPTION
It seems that the default for this particular method was overlooked in !163