### PR TITLE
Add cast=str to str() method

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -131,7 +131,7 @@ class Env(object):
         """
         :rtype: str
         """
-        value = self.get_value(var, default=default)
+        value = self.get_value(var, cast=str, default=default)
         if multiline:
             return value.replace('\\n', '\n')
         return value


### PR DESCRIPTION
fix for something i noticed when investigating #192.

    # does not return the value of the env var, even if it is set
    # because of type casting based on the default type
    >>> env.str('GOOGLE_ANALYTICS_KEY', default=True)
    False

    >>> import os
    >>> os.environ['GOOGLE_ANALYTICS_KEY']
    'UA-123456-78'