### PR TITLE
Set long_description_content_type in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/x-rst",
     keywords='django environment variables 12factor',
     author=AUTHOR,
     author_email=EMAIL,


### PR DESCRIPTION
Hopefully then https://pypi.org/project/django-environ/ will render the `long_description` more usefully!