### PR TITLE
Changes django-environ to modify a copy of the environment

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -117,14 +117,19 @@ class Env(object):
     }
 
     def __init__(self, **scheme):
-        self.ENVIRON.update(os.environ)
+        if Env.ENVIRON == {}:
+            Env.ENVIRON = dict(os.environ)
         self.scheme = scheme
 
     def __call__(self, var, cast=None, default=NOTSET, parse_default=False):
         return self.get_value(var, cast=cast, default=default, parse_default=parse_default)
 
     def __contains__(self, var):
-        return var in self.ENVIRON
+        try:
+            self.get_value(var)
+            return True
+        except ImproperlyConfigured:
+            return False
 
     # Shortcuts
 

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -55,7 +55,7 @@ class Env(object):
             ...
     """
 
-    ENVIRON = os.environ
+    ENVIRON = {}
     NOTSET = NoValue()
     BOOLEAN_TRUE_STRINGS = ('true', 'on', 'ok', 'y', 'yes', '1')
     URL_CLASS = ParseResult
@@ -117,6 +117,7 @@ class Env(object):
     }
 
     def __init__(self, **scheme):
+        self.ENVIRON.update(os.environ)
         self.scheme = scheme
 
     def __call__(self, var, cast=None, default=NOTSET, parse_default=False):

--- a/environ/test.py
+++ b/environ/test.py
@@ -81,7 +81,7 @@ class BaseTests(unittest.TestCase):
             Env.ENVIRON.setdefault(key, val)
 
     def tearDown(self):
-        os.environ = dict(os.environ.items() - self.generateEnvironment())
+        os.environ = {key:value for key, value in os.environ.items() if key not in self.generateEnvironment()}
         os.environ.update(self._old_environ)
 
     def assertTypeAndValue(self, type_, expected, actual):


### PR DESCRIPTION
This prevents django-environ's use of os.environ making changes to the ACTUAL environment. All other behavior kept the same. This fixes issues with UWSGI emperor mode where the environment is persistent between vassal restarts leading to any variable set in a .env file becoming semi-permanent as django-environ won't overwrite existing environment settings.

Instead of the old fix, which only copied the os.environ in read_env, this pull shallow copies os.environ inside env.__init__, meaning that we always have a copy of the environment whether we read an .env file or not.

All tests passing.