### PR TITLE
Value of dict can contain an equal sign.

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -326,7 +326,7 @@ class Env(object):
                 [val.split('=') for val in value.split(';') if val]
             ))
         elif cast is dict:
-            value = dict([val.split('=') for val in value.split(',') if val])
+            value = dict([val.split('=', 1) for val in value.split(',') if val])
         elif cast is list:
             value = [x for x in value.split(',') if x]
         elif cast is tuple:


### PR DESCRIPTION
In this case, if type of variable is dict, we have an error: **key1='testtest=dsd',key2='weedsd'**. Value can contain an equal sign.