### PR TITLE
Stop raising UserWarning if .env file isn't found

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -749,7 +749,7 @@ class Env:
                 '.env'
             )
             if not os.path.exists(env_file):
-                warnings.warn(
+                logger.info(
                     "%s doesn't exist - if you're not configuring your "
                     "environment separately, create one." % env_file)
                 return
@@ -762,8 +762,8 @@ class Env:
                 with env_file as f:
                     content = f.read()
         except OSError:
-            warnings.warn(
-                "Error reading %s - if you're not configuring your "
+            logger.info(
+                "%s not found - if you're not configuring your "
                 "environment separately, check this." % env_file)
             return
 


### PR DESCRIPTION
Currently, if a `.env` file isn't found by the read_env() classmethod, it raises a UserWarning. Based on Python's logging guide, warnings.warn() is only appropriate to be raised in library code if the
issue is avoidable and the client application should be modified to eliminate the warning.

Conversely, it recommends logging.warning() if there is nothing the client application can do about the situation, but the event should still be noted.

https://docs.python.org/3/howto/logging.html#when-to-use-logging

In this particular case, the function is working with `.env` files that should only ever exist in development environments, which means that the function will erroneously warn the consumer in production and staging environments.

With this in mind, I believe the most sensible thing to do would be to convert read_env from using the warnings module to using the logging module. Additionally, since the lack of a `.env` file is going to occur regularly during normal operation of the program, I also believe that this should be downgraded to an INFO level message from a WARNING level message.

joke2k/django-environ#243 requests that the .env file be made optional, and as far as I can the .env file is indeed optional, it's just that a UserWarning is being raised instead of a logged message. With that in mind, I'm referencing it as being closed by this change.

fixes: joke2k/django-environ#243