### PR TITLE
Remove "filthy magic stack backtracking" in favor of BASE_DIR

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -741,7 +741,7 @@ class Env:
             try:
                 from django.conf import settings
                 env_file = os.path.join(settings.BASE_DIR, '.env')
-            except ImportError:
+            except (ImportError, NameError):
                 logger.info(
                     "%s doesn't exist - if you're not configuring your "
                     "environment separately, create one." % env_file)


### PR DESCRIPTION
The `read_env` documentation currently states:

> If not given a path to a dotenv path, does filthy magic stack backtracking to find manage.py and then find the dotenv.

Based on joke2k/django-environ#88, it appears that this behavior is rather fragile.

To improve this, I think the package should document that read_env expects you to provide a path. If one is not provided, it will attempt to use the BASE_DIR constant from the django settings module. If an ImportError is encountered while it attempts to do this, read_env will assume there's no .env file to be found, log an info message to that effect, and continue on.

fixes: joke2k/django-environ#88