### PR TITLE
README.rst: Fix typo in Smart Casting section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,7 @@ Smart Casting
 
 django-environ has a "Smart-casting" enabled by default, if you don't provide a ``cast`` type, it will be detected from ``default`` type.
 This could raise side effects (see `#192 <https://github.com/joke2k/django-environ/issues/192>`_).
-To disable it use ``env.smart_caset = False``.
+To disable it use ``env.smart_cast = False``.
 New major release will disable it as default. 
 
 


### PR DESCRIPTION
Update README.rst to correct a typo in the configuration needed to disable smart casting.