### PR TITLE
Added ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
   - DJANGO="Django==2.2.*"
   - DJANGO="Django==3.0.*"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
+arch:
+  - amd64
+  - ppc64le
 matrix:
   exclude:
     - env: DJANGO="Django==1.11.*"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-environ/builds/186495000

Please have a look.

Regards,
Kishor Kunal Raj