### PR TITLE
Allows use of Path objects when reading env from the filesystem.

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -644,7 +644,7 @@ class Env:
                 return
 
         try:
-            with open(env_file) if isinstance(env_file, str) else env_file as f:
+            with open(env_file) if isinstance(env_file, (str, Path)) else env_file as f:
                 content = f.read()
         except OSError:
             warnings.warn(


### PR DESCRIPTION
Allows use of `read_env(BASE_DIR / '.env')` instead of `read_env(os.path.join(BASE_DIR, '.env'))`