### PR TITLE
Updated readme.md with arguments to environ.Env.read_env()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,9 @@ Django-environ
         # set casting, default value
         DEBUG=(bool, False)
     )
+    BASE_DIR = # PATH TO BASE_DIR
     # reading .env file
-    environ.Env.read_env()
+    environ.Env.read_env(env_file=os.path.join(BASE_DIR, '.env'))
 
     # False if not in os.environ
     DEBUG = env('DEBUG')


### PR DESCRIPTION
fixes the issue of 'environ.Env.read_env()' was not reading the ".env" file in certain situations.
for me
BASE_DIR = BASE_DIR = Path(__file__).resolve().parent.parent
so ".env" file was not not being read. This fixes the issue