### PR TITLE
Revert "added env variable to point to .env file"

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -748,7 +748,6 @@ class Env:
                 os.path.dirname(frame.f_back.f_code.co_filename),
                 '.env'
             )
-            env_file = os.environ.get('ENV_FILE') or env_file
             if not os.path.exists(env_file):
                 logger.info(
                     "%s doesn't exist - if you're not configuring your "

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -351,18 +351,3 @@ class TestSubClass(TestEnv):
 
     def test_singleton_environ(self):
         assert self.CONFIG is self.env.ENVIRON
-
-
-class FileEnvByEnvVarTests(TestEnv):
-
-    def setup_method(self, method):
-        super(FileEnvByEnvVarTests, self).setUp()
-        with open('./tmp/test_env.txt') as env_file:
-            env_file.writeline('VAR=TEST')
-        Env.ENVIRON = {}
-        os.environ['ENV_FILE'] = './tmp/test_env.txt'
-        self.env = Env()
-
-    def test_read_env(self):
-        assert_type_and_value(str, 'TEST', self.env('VAR'))
-


### PR DESCRIPTION
Reverts joke2k/django-environ#242


---

@variable I'm sorry, but https://github.com/joke2k/django-environ/pull/242 provides a redundant feature. Right now django-environ provides a possibility to use any .env file location using the following approach:

```sh
# .secret file contents
SOME_VAR=3.14
```

```console
$ export ACTUAL_ENV_FILE=$(pwd)/.secret

$ python -c 'from environ.environ import Env
> env = Env()
> env.read_env(env.str("ACTUAL_ENV_FILE", ".env"))
> print(env("SOME_VAR"))'
3.14
```

The key point is to use:
```py
env.read_env(env.str("ACTUAL_ENV_FILE", ".env"))

# OR

env.read_env(env_file=env.str("ACTUAL_ENV_FILE", ".env"))
```

Thus, will be used `.env` if `ACTUAL_ENV_FILE` environment variable is not defined.  This feature has been documented in https://github.com/joke2k/django-environ/pull/155.

I'd like django-environ remain simple as long as possible. I'd not complicate its codebase without an urgent and obvious need.  Therefore, I have to roll it back. I'm sorry.