### PR TITLE
Support line breaks and comments in .env file

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -821,6 +821,9 @@ class Env:
                     val = re.sub(r'\\(.)', _keep_escaped_format_characters,
                                  m3.group(1))
                 overrides[key] = str(val)
+            elif not line or line.startswith('#'):
+                # ignore warnings for empty line-breaks or comments
+                pass
             else:
                 logger.warning('Invalid line: %s', line)
 

--- a/tests/test_env.txt
+++ b/tests/test_env.txt
@@ -1,10 +1,18 @@
 DICT_VAR=foo=bar,test=on
+
+# Database variables
 DATABASE_MYSQL_URL=mysql://bea6eb0:69772142@us-cdbr-east.cleardb.com/heroku_97681?reconnect=true
 DATABASE_MYSQL_CLOUDSQL_URL=mysql://djuser:hidden-password@//cloudsql/arvore-codelab:us-central1:mysqlinstance/mydatabase
 DATABASE_MYSQL_GIS_URL=mysqlgis://user:password@127.0.0.1/some_database
+
+# Cache variables
 CACHE_URL=memcache://127.0.0.1:11211
 CACHE_REDIS=rediscache://127.0.0.1:6379/1?client_class=django_redis.client.DefaultClient&password=secret
+
+# Email variables
 EMAIL_URL=smtps://user@domain.com:password@smtp.example.com:587
+
+# Others
 URL_VAR=http://www.google.com/
 PATH_VAR=/home/dev
 BOOL_TRUE_STRING_LIKE_INT='1'
@@ -45,4 +53,6 @@ DATABASE_ORACLE_TNS_URL=oracle://user:password@sid
 DATABASE_ORACLE_URL=oracle://user:password@host:1521/sid
 DATABASE_REDSHIFT_URL=redshift://user:password@examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev
 DATABASE_CUSTOM_BACKEND_URL=custom.backend://user:password@example.com:5430/database
+
+# Exports
 export EXPORTED_VAR="exported var"


### PR DESCRIPTION
Commit https://github.com/joke2k/django-environ/pull/283/commit added useful warnings for skipped lines.
However, it also started showing warnings for comments.

Like in `.zshrc`, we add comments using hash (#). We also group common
blocks together.

Our env files look something like:
```env
SECRET_KEY="S0M3#SecreT"
DATABASE_URL=mysql://py-user:p@@sWord@127.0.0.1:3306/db_name

# Other services (not must to change)
## Google social login
GOOGLE_CLIENT_ID=""
GOOGLE_CLIENT_SECRET=""
```

I am not sure if the project intends to support comments.
Will request you please support them if possible :)