### PR TITLE
Add django-mailer to supported email schemes

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -56,6 +56,7 @@ Supported types
   * SMTP: ``smtp://``
   * SMTP+SSL: ``smtp+ssl://``
   * SMTP+TLS: ``smtp+tls://``
+  * django-mailer: ``djangomailer://``
   * Console mail: ``consolemail://``
   * File mail: ``filemail://``
   * LocMem mail: ``memorymail://``

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -57,6 +57,8 @@ Supported types
   * SMTP+SSL: ``smtp+ssl://``
   * SMTP+TLS: ``smtp+tls://``
   * django-mailer: ``djangomailer://``
+  * django-mailer+SSL: ``djangomailer+ssl://``
+  * django-mailer+TLS: ``djangomailer+tls://``
   * Console mail: ``consolemail://``
   * File mail: ``filemail://``
   * LocMem mail: ``memorymail://``

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -143,6 +143,8 @@ class Env:
         'smtp+tls': 'django.core.mail.backends.smtp.EmailBackend',
         'smtp+ssl': 'django.core.mail.backends.smtp.EmailBackend',
         'djangomailer': 'mailer.backend.DbBackend',
+        'djangomailer+tls': 'mailer.backend.DbBackend',
+        'djangomailer+ssl': 'mailer.backend.DbBackend',
         'consolemail': 'django.core.mail.backends.console.EmailBackend',
         'filemail': 'django.core.mail.backends.filebased.EmailBackend',
         'memorymail': 'django.core.mail.backends.locmem.EmailBackend',
@@ -652,9 +654,9 @@ class Env:
         elif url.scheme in cls.EMAIL_SCHEMES:
             config['EMAIL_BACKEND'] = cls.EMAIL_SCHEMES[url.scheme]
 
-        if url.scheme in ('smtps', 'smtp+tls'):
+        if url.scheme in ('smtps', 'smtp+tls', 'djangomailer+tls'):
             config['EMAIL_USE_TLS'] = True
-        elif url.scheme == 'smtp+ssl':
+        elif url.scheme in ('smtp+ssl', 'djangomailer+ssl'):
             config['EMAIL_USE_SSL'] = True
 
         if url.query:

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -142,6 +142,7 @@ class Env:
         'smtps': 'django.core.mail.backends.smtp.EmailBackend',
         'smtp+tls': 'django.core.mail.backends.smtp.EmailBackend',
         'smtp+ssl': 'django.core.mail.backends.smtp.EmailBackend',
+        'djangomailer': 'mailer.backend.DbBackend',
         'consolemail': 'django.core.mail.backends.console.EmailBackend',
         'filemail': 'django.core.mail.backends.filebased.EmailBackend',
         'memorymail': 'django.core.mail.backends.locmem.EmailBackend',


### PR DESCRIPTION
Support django-mailer as email backend.

See #385 