### PR TITLE
Add core redis compat if django 4+

### DIFF
--- a/environ/compat.py
+++ b/environ/compat.py
@@ -25,8 +25,11 @@ else:
     class ImproperlyConfigured(Exception):
         pass
 
+# use built-in support if Django 4+
+if DJANGO_VERSION is not None and DJANGO_VERSION >= (4, 0):
+    REDIS_DRIVER='django.core.cache.backends.redis.RedisCache'
 # back compatibility with redis_cache package
-if find_loader('redis_cache'):
+elif find_loader('redis_cache'):
     REDIS_DRIVER = 'redis_cache.RedisCache'
 else:
     REDIS_DRIVER = 'django_redis.cache.RedisCache'

--- a/environ/compat.py
+++ b/environ/compat.py
@@ -25,14 +25,17 @@ else:
     class ImproperlyConfigured(Exception):
         pass
 
-# use built-in support if Django 4+
-if DJANGO_VERSION is not None and DJANGO_VERSION >= (4, 0):
-    REDIS_DRIVER='django.core.cache.backends.redis.RedisCache'
-# back compatibility with redis_cache package
-elif find_loader('redis_cache'):
-    REDIS_DRIVER = 'redis_cache.RedisCache'
-else:
-    REDIS_DRIVER = 'django_redis.cache.RedisCache'
+
+def choose_rediscache_driver():
+    """Backward compatibility for RedisCache driver."""
+    # use built-in support if Django 4+
+    if DJANGO_VERSION is not None and DJANGO_VERSION >= (4, 0):
+        return 'django.core.cache.backends.redis.RedisCache'
+    # back compatibility with redis_cache package
+    elif find_loader('redis_cache'):
+        return 'redis_cache.RedisCache'
+    else:
+        return 'django_redis.cache.RedisCache'
 
 
 def choose_postgres_driver():
@@ -52,6 +55,9 @@ def choose_pymemcache_driver():
         return 'django.core.cache.backends.memcached.PyLibMCCache'
     return 'django.core.cache.backends.memcached.PyMemcacheCache'
 
+
+REDIS_DRIVER = choose_rediscache_driver()
+"""The name of the RedisCache driver."""
 
 DJANGO_POSTGRES = choose_postgres_driver()
 """The name of the PostgreSQL driver."""

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,7 +7,6 @@
 # the LICENSE.txt file that was distributed with this source code.
 
 from unittest import mock
-from environ import compat
 
 import pytest
 
@@ -55,7 +54,7 @@ def test_base_options_parsing():
         ('rediscache://host1:6379,host2:6379,host3:9999/1', REDIS_DRIVER,
          ['redis://host1:6379/1', 'redis://host2:6379/1',
           'redis://host3:9999/1']),
-        ('rediscache:///path/to/socket:1', compat.choose_rediscache_driver(),
+        ('rediscache:///path/to/socket:1', REDIS_DRIVER,
          'unix:///path/to/socket:1'),
         ('memcache:///tmp/memcached.sock',
          'django.core.cache.backends.memcached.MemcachedCache',
@@ -186,14 +185,12 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     monkeypatch.setenv('CACHE_URL', url)
     env = Env()
 
-    redis_backend = compat.choose_rediscache_driver()
-
     result = env.cache()
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:sec{}ret@ondigitalocean.com:25061/2'.format(chars)
@@ -201,11 +198,11 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:{}secret@ondigitalocean.com:25061/2'.format(chars)
@@ -213,11 +210,11 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
 
@@ -232,10 +229,8 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     monkeypatch.setenv('CACHE_URL', url)
     env = Env()
 
-    redis_backend = compat.choose_rediscache_driver()
-
     result = env.cache()
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:sec{}ret@ondigitalocean.com:25061/2'.format(chars)
@@ -243,7 +238,7 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:{}secret@ondigitalocean.com:25061/2'.format(chars)
@@ -251,7 +246,7 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == redis_backend
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,6 +7,7 @@
 # the LICENSE.txt file that was distributed with this source code.
 
 from unittest import mock
+from environ import compat
 
 import pytest
 
@@ -54,7 +55,7 @@ def test_base_options_parsing():
         ('rediscache://host1:6379,host2:6379,host3:9999/1', REDIS_DRIVER,
          ['redis://host1:6379/1', 'redis://host2:6379/1',
           'redis://host3:9999/1']),
-        ('rediscache:///path/to/socket:1', 'django_redis.cache.RedisCache',
+        ('rediscache:///path/to/socket:1', compat.choose_rediscache_driver(),
          'unix:///path/to/socket:1'),
         ('memcache:///tmp/memcached.sock',
          'django.core.cache.backends.memcached.MemcachedCache',
@@ -185,12 +186,14 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     monkeypatch.setenv('CACHE_URL', url)
     env = Env()
 
+    redis_backend = compat.choose_rediscache_driver()
+
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:sec{}ret@ondigitalocean.com:25061/2'.format(chars)
@@ -198,11 +201,11 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:{}secret@ondigitalocean.com:25061/2'.format(chars)
@@ -210,11 +213,11 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
 
@@ -229,8 +232,10 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     monkeypatch.setenv('CACHE_URL', url)
     env = Env()
 
+    redis_backend = compat.choose_rediscache_driver()
+
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:sec{}ret@ondigitalocean.com:25061/2'.format(chars)
@@ -238,7 +243,7 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:{}secret@ondigitalocean.com:25061/2'.format(chars)
@@ -246,7 +251,7 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == redis_backend
     assert result['LOCATION'] == url
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -8,13 +8,11 @@
 
 import os
 from urllib.parse import quote
-from environ import compat
 
 import pytest
 
-import environ.compat
 from environ import Env, Path
-from environ.compat import ImproperlyConfigured, DJANGO_POSTGRES
+from environ.compat import DJANGO_POSTGRES, REDIS_DRIVER, ImproperlyConfigured
 from .asserts import assert_type_and_value
 from .fixtures import FakeEnv
 
@@ -277,7 +275,7 @@ class TestEnv:
             (Env.DEFAULT_CACHE_ENV,
              'django.core.cache.backends.memcached.MemcachedCache',
              '127.0.0.1:11211', None),
-            ('CACHE_REDIS', compat.choose_rediscache_driver(),
+            ('CACHE_REDIS', REDIS_DRIVER,
              'redis://127.0.0.1:6379/1',
              {'CLIENT_CLASS': 'django_redis.client.DefaultClient',
               'PASSWORD': 'secret'}),

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -8,9 +8,11 @@
 
 import os
 from urllib.parse import quote
+from environ import compat
 
 import pytest
 
+import environ.compat
 from environ import Env, Path
 from environ.compat import ImproperlyConfigured, DJANGO_POSTGRES
 from .asserts import assert_type_and_value
@@ -275,7 +277,7 @@ class TestEnv:
             (Env.DEFAULT_CACHE_ENV,
              'django.core.cache.backends.memcached.MemcachedCache',
              '127.0.0.1:11211', None),
-            ('CACHE_REDIS', 'django_redis.cache.RedisCache',
+            ('CACHE_REDIS', compat.choose_rediscache_driver(),
              'redis://127.0.0.1:6379/1',
              {'CLIENT_CLASS': 'django_redis.client.DefaultClient',
               'PASSWORD': 'secret'}),


### PR DESCRIPTION
Resolves #356

Now django-environ supports Django 4.0, this feature can be added: use the core redis library by default if running Django 4.0


(Would appreciate input how to best test this)