### PR TITLE
Skip parsing only when `default=None`, not for all default values that coerce to `False`

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -409,7 +409,7 @@ class Env:
 
         value = None if default is None and value == '' else value
 
-        if value != default or (parse_default and value):
+        if value != default or (parse_default and value is not None):
             value = self.parse_value(value, cast)
 
         return value

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -227,6 +227,13 @@ class TestEnv:
         assert url.geturl() == FakeEnv.URL
         assert self.env.url('OTHER_URL', default=None) is None
 
+    def test_url_empty_string_default_value(self):
+        unset_var_name = 'VARIABLE_NOT_SET_IN_ENVIRONMENT'
+        assert unset_var_name not in os.environ
+        url = self.env.url(unset_var_name, '')
+        assert url.__class__ == self.env.URL_CLASS
+        assert url.geturl() == ''
+
     def test_url_encoded_parts(self):
         password_with_unquoted_characters = "#password"
         encoded_url = "mysql://user:%s@127.0.0.1:3306/dbname" % quote(


### PR DESCRIPTION
Fixes joke2k/django-environ#404