### PR TITLE
Change default Redis driver to support Django 4

### DIFF
--- a/environ/compat.py
+++ b/environ/compat.py
@@ -33,10 +33,10 @@ else:
     DJANGO_POSTGRES = 'django.db.backends.postgresql'
 
 # back compatibility with redis_cache package
-if DJANGO_VERSION is not None and DJANGO_VERSION >= (4, 0):
-    REDIS_DRIVER = 'django.core.cache.backends.redis.RedisCache'
-elif find_loader('redis_cache'):
+if find_loader('redis_cache'):
     REDIS_DRIVER = 'redis_cache.RedisCache'
+elif DJANGO_VERSION >= (4, 0) and not find_loader('django_redis'):
+    REDIS_DRIVER = 'django.core.cache.backends.redis.RedisCache'
 else:
     REDIS_DRIVER = 'django_redis.cache.RedisCache'
 

--- a/environ/compat.py
+++ b/environ/compat.py
@@ -35,7 +35,7 @@ else:
 # back compatibility with redis_cache package
 if find_loader('redis_cache'):
     REDIS_DRIVER = 'redis_cache.RedisCache'
-elif DJANGO_VERSION >= (4, 0) and not find_loader('django_redis'):
+elif not find_loader('django_redis') and DJANGO_VERSION is not None and DJANGO_VERSION >= (4, 0):
     REDIS_DRIVER = 'django.core.cache.backends.redis.RedisCache'
 else:
     REDIS_DRIVER = 'django_redis.cache.RedisCache'

--- a/environ/compat.py
+++ b/environ/compat.py
@@ -33,7 +33,9 @@ else:
     DJANGO_POSTGRES = 'django.db.backends.postgresql'
 
 # back compatibility with redis_cache package
-if find_loader('redis_cache'):
+if DJANGO_VERSION is not None and DJANGO_VERSION >= (4, 0):
+    REDIS_DRIVER = 'django.core.cache.backends.redis.RedisCache'
+elif find_loader('redis_cache'):
     REDIS_DRIVER = 'redis_cache.RedisCache'
 else:
     REDIS_DRIVER = 'django_redis.cache.RedisCache'

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -54,7 +54,7 @@ def test_base_options_parsing():
         ('rediscache://host1:6379,host2:6379,host3:9999/1', REDIS_DRIVER,
          ['redis://host1:6379/1', 'redis://host2:6379/1',
           'redis://host3:9999/1']),
-        ('rediscache:///path/to/socket:1', 'django_redis.cache.RedisCache',
+        ('rediscache:///path/to/socket:1', REDIS_DRIVER,
          'unix:///path/to/socket:1'),
         ('memcache:///tmp/memcached.sock',
          'django.core.cache.backends.memcached.MemcachedCache',
@@ -186,11 +186,11 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:sec{}ret@ondigitalocean.com:25061/2'.format(chars)
@@ -198,11 +198,11 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:{}secret@ondigitalocean.com:25061/2'.format(chars)
@@ -210,11 +210,11 @@ def test_cache_url_password_using_sub_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     result = env.cache_url_config(url)
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
 
@@ -230,7 +230,7 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:sec{}ret@ondigitalocean.com:25061/2'.format(chars)
@@ -238,7 +238,7 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
     url = 'rediss://enigma:{}secret@ondigitalocean.com:25061/2'.format(chars)
@@ -246,7 +246,7 @@ def test_cache_url_password_using_gen_delims(monkeypatch, chars):
     env = Env()
 
     result = env.cache()
-    assert result['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert result['BACKEND'] == REDIS_DRIVER
     assert result['LOCATION'] == url
 
 


### PR DESCRIPTION
Fix [#434]: change default Redis driver to support Django 4
- this commit already included changes about testing case.
- all test in `test_cache.py` was passed.
- it may be **NOT** a perfect change for other user which want to use `django_redis` in Django 4.0+ by default.