### PR TITLE
Delete duplicated include in docs/quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -2,10 +2,6 @@
 Quick Start
 ===========
 
-.. include:: ../README.rst
-   :start-after: -code-begin-
-   :end-before: -overview-
-
 Usage
 =====
 


### PR DESCRIPTION
We have same include on line [26](https://github.com/joke2k/django-environ/blame/main/docs/quickstart.rst#L26)