### PR TITLE
Update SQL Server engine as mssql-django

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is inspired by `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+`v0.10.1`_ - 6-March-2023
+------------------------------
+Changed
++++++++
+- Used `mssql-django` as engine for SQL Server.
+
+
 `v0.10.0`_ - 2-March-2023
 -------------------------------
 Added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is inspired by `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-`v0.10.1`_ - 6-March-2023
+`v0.10.1`_ - 5-March-2023
 ------------------------------
 Changed
 +++++++
 - Used `mssql-django` as engine for SQL Server.
+  `#446 <https://github.com/joke2k/django-environ/pull/446>`_.
 
 
 `v0.10.0`_ - 2-March-2023

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -121,7 +121,7 @@ class Env:
         'mysql2': 'django.db.backends.mysql',
         'mysql-connector': 'mysql.connector.django',
         'mysqlgis': 'django.contrib.gis.db.backends.mysql',
-        'mssql': 'sql_server.pyodbc',
+        'mssql': 'mssql',
         'oracle': 'django.db.backends.oracle',
         'pyodbc': 'sql_server.pyodbc',
         'redshift': 'django_redshift_backend',

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -118,7 +118,7 @@ from environ.compat import DJANGO_POSTGRES
         # mysql://user:password@host/dbname
         ('mssql://enigma:secret@example.com/dbname'
          '?driver=ODBC Driver 13 for SQL Server',
-         'sql_server.pyodbc',
+         'mssql',
          'dbname',
          'example.com',
          'enigma',
@@ -127,7 +127,7 @@ from environ.compat import DJANGO_POSTGRES
         # mysql://user:password@host:port/dbname
         ('mssql://enigma:secret@amazonaws.com\\insnsnss:12345/dbname'
          '?driver=ODBC Driver 13 for SQL Server',
-         'sql_server.pyodbc',
+         'mssql',
          'dbname',
          'amazonaws.com\\insnsnss',
          'enigma',


### PR DESCRIPTION
As pointed in #295 , [mssql-django](https://pypi.org/project/mssql-django/) is an official django-mssql-backend port by Microsoft in the making. Besides, this package is also the only backend mentioned in django docuent for SQL Server ( https://docs.djangoproject.com/en/4.1/ref/databases/#using-a-3rd-party-database-backend ) .

Based on the document of `mssql-django`, the name of name should be `mssql`, so I changed it.

BTW, it's my regret to get known to `django-environ` so late, before which I was always struggling with a mess of varaibles in `.env` like "MYSQL_USER", "MYSQL_PASSWD", "DATABASE_ENGINE" to manage the different database between development and production environment. Thank you!