### PR TITLE
Add URL encoding to handle special characters in passwords

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -23,6 +23,7 @@ from urllib.parse import (
     ParseResult,
     unquote,
     unquote_plus,
+    quote,
     urlparse,
     urlunparse,
 )
@@ -509,7 +510,7 @@ class Env:
                     'NAME': ':memory:'
                 }
                 # note: no other settings are required for sqlite
-            url = urlparse(url)
+            url = urlparse(quote(url, safe=':/?&=@'))
 
         config = {}
 


### PR DESCRIPTION
The safe parameter has been set to exclude :/?&=@ characters from encoding, while still encoding others. This change ensures that passwords with special characters are properly encoded to preventing potential URL parsing errors.