### PR TITLE
Test on Django 4.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ the code on `GitHub <https://github.com/joke2k/django-environ>`_,
 and the latest release on `PyPI <https://pypi.org/project/django-environ/>`_.
 
 It’s rigorously tested on Python 3.5+, and officially supports
-Django 1.11, 2.2, 3., 3.1, 3.2, 4.0 and 4.1.
+Django 1.11, 2.2, 3., 3.1, 3.2, 4.0, 4.1, and 4.2.
 
 If you'd like to contribute to ``django-environ`` you're most welcome!
 

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
     'Framework :: Django :: 4.1',
+    'Framework :: Django :: 4.2',
 
     'Operating System :: OS Independent',
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ envlist =
     manifest
     py{35,36,37,38,39,310,311}-django{111,22}
     py{36,37,38,39,310,311}-django{30,31,32}
-    py{38,39,310,311}-django{40,41}
+    py{38,39,310,311}-django{40,41,42}
     pypy-django{111,22,30,31,32}
 
 [gh-actions]
@@ -45,6 +45,7 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
 commands_pre =
     python -m pip install --upgrade pip
     python -m pip install .


### PR DESCRIPTION
Copied the changes from #425 for the new Django LTS.

I ran the test suite locally and it passed with no new warnings, so the existing version is compatible.