### PR TITLE
♻️Refactor the README and tox.ini 

### DIFF
--- a/BACKERS.rst
+++ b/BACKERS.rst
@@ -21,7 +21,7 @@ Thank you to all our backers!
 |ocbackerimage|
 
 .. |ocsponsor0| image:: https://opencollective.com/django-environ/sponsor/0/avatar.svg
-    :target: https://triplebyte.com/
+    :target: https://opencollective.com/triplebyte
     :alt: Sponsor
 .. |ocsponsor1| image:: https://images.opencollective.com/static/images/become_sponsor.svg
     :target: https://opencollective.com/django-environ/contribute/sponsors-3474/checkout

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ the code on `GitHub <https://github.com/joke2k/django-environ>`_,
 and the latest release on `PyPI <https://pypi.org/project/django-environ/>`_.
 
 It’s rigorously tested on Python 3.6+, and officially supports
-Django 1.11, 2.2, 3., 3.1, 3.2, 4.0, 4.1, and 4.2.
+Django 1.11, 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, and 4.2.
 
 If you'd like to contribute to ``django-environ`` you're most welcome!
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
-    django42: Django>=4.2rc1,<5.0
+    django42: Django>=4.2,<5.0
 commands_pre =
     python -m pip install --upgrade pip
     python -m pip install .


### PR DESCRIPTION
to correct a typo in README
and to make the tox.ini consistent by dropping the rc1 for Django 4.2

related to #456 