### PR TITLE
Use importlib.util.find_spec to replace pkgutil.find_loader

### DIFF
--- a/environ/compat.py
+++ b/environ/compat.py
@@ -8,14 +8,14 @@
 
 """This module handles import compatibility issues."""
 
-from pkgutil import find_loader
+from importlib.util import find_spec
 
-if find_loader('simplejson'):
+if find_spec('simplejson'):
     import simplejson as json
 else:
     import json
 
-if find_loader('django'):
+if find_spec('django'):
     from django import VERSION as DJANGO_VERSION
     from django.core.exceptions import ImproperlyConfigured
 else:
@@ -29,7 +29,7 @@ def choose_rediscache_driver():
     """Backward compatibility for RedisCache driver."""
 
     # django-redis library takes precedence
-    if find_loader('django_redis'):
+    if find_spec('django_redis'):
         return 'django_redis.cache.RedisCache'
 
     # use built-in support if Django 4+
@@ -51,7 +51,7 @@ def choose_postgres_driver():
 def choose_pymemcache_driver():
     """Backward compatibility for pymemcache."""
     old_django = DJANGO_VERSION is not None and DJANGO_VERSION < (3, 2)
-    if old_django or not find_loader('pymemcache'):
+    if old_django or not find_spec('pymemcache'):
         # The original backend choice for the 'pymemcache' scheme is
         # unfortunately 'pylibmc'.
         return 'django.core.cache.backends.memcached.PyLibMCCache'

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -107,8 +107,8 @@ def test_pymemcache_compat(django_version, pymemcache_installed):
     old = 'django.core.cache.backends.memcached.PyLibMCCache'
     new = 'django.core.cache.backends.memcached.PyMemcacheCache'
     with mock.patch.object(environ.compat, 'DJANGO_VERSION', django_version):
-        with mock.patch('environ.compat.find_loader') as mock_find_loader:
-            mock_find_loader.return_value = pymemcache_installed
+        with mock.patch('environ.compat.find_spec') as mock_find_spec:
+            mock_find_spec.return_value = pymemcache_installed
             driver = environ.compat.choose_pymemcache_driver()
             if django_version and django_version < (3, 2):
                 assert driver == old
@@ -124,8 +124,8 @@ def test_rediscache_compat(django_version, django_redis_installed):
     django_redis = 'django_redis.cache.RedisCache'
 
     with mock.patch.object(environ.compat, 'DJANGO_VERSION', django_version):
-        with mock.patch('environ.compat.find_loader') as mock_find_loader:
-            mock_find_loader.return_value = django_redis_installed
+        with mock.patch('environ.compat.find_spec') as mock_find_spec:
+            mock_find_spec.return_value = django_redis_installed
             driver = environ.compat.choose_rediscache_driver()
             if django_redis_installed:
                 assert driver == django_redis


### PR DESCRIPTION
Aim: suppress the warning in #479 

`importlib.util.find_spec` is available from python 3.4, so it is compatible with python 3.6+