### PR TITLE
Allow separate declaration and assignment to avoid masking return values

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -925,7 +925,7 @@ class Env:
             return escaped_char
 
         for line in content.splitlines():
-            m1 = re.match(r'\A(?:export )?([A-Za-z_0-9]+)=(.*)\Z', line)
+            m1 = re.match(r'\A(?:export )?([A-Za-z_0-9]+)(?:=)?(.*)\Z', line)
             if m1:
                 key, val = m1.group(1), m1.group(2)
                 # Look for value in quotes, ignore post-# comments


### PR DESCRIPTION
In a project, I was trying to follow a best practice of assigning values to variables on different lines than where I export them. Seems that it's possible to have a bad return code from `my_func` ignored if it's all on the same line. I don't know if anything is going to try and catch the failure here, but why prevent it? Here is an example of code that was being called bad:

```sh
MY_NAME="$(my_func)"
export MY_NAME
```

I haven't exhaustively tested the change, but it does pass the existing tests. The value in my code is made available where I want it.