### PR TITLE
add sphinx configuration for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,3 +25,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
New requirement from readthedocs: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

We have time until "Monday, January 20, 2025: Permanently disallow building projects."