### PR TITLE
feat(cache): add valkey and valkeys as allowed schemes

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -148,6 +148,8 @@ class Env:
         'rediscache': REDIS_DRIVER,
         'redis': REDIS_DRIVER,
         'rediss': REDIS_DRIVER,
+        'valkey': REDIS_DRIVER,
+        'valkeys': REDIS_DRIVER,
     }
     _CACHE_BASE_OPTIONS = [
         'TIMEOUT',


### PR DESCRIPTION
This PR adds the alternative schemes `valkey` and `valkeys`, which is also the recommendation from `django-valkey`.

---
Valkey is an open source drop-in replacement for Redis:
> This project was forked from the open source Redis project right before the transition to their new source available licenses.
(https://github.com/valkey-io/valkey)

https://django-valkey.readthedocs.io/en/latest/configure/advanced_configurations.html