### PR TITLE
Rework supported environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ the code on `GitHub <https://github.com/joke2k/django-environ>`_,
 and the latest release on `PyPI <https://pypi.org/project/django-environ/>`_.
 
 It’s rigorously tested on Python 3.9+, and officially supports
-Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.0, and 5.1.
+Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.0, 5.1 and 5.2.
 
 If you'd like to contribute to ``django-environ`` you're most welcome!
 

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
+    'Framework :: Django :: 5.2',
 
     'Operating System :: OS Independent',
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,10 +42,10 @@ from environ.compat import DJANGO_POSTGRES
          'secret',
          5431),
         # postgres://user:password@host:port,host:port,host:port/dbname
-        ('postgres://username:p@ss:12,wor:34d@host1:111,22.55.44.88:222,[2001:db8::1234]:333/db',
+        ('postgres://username:p@ss:12,wor:34d@host1:111,22.55.44.88:222,2001:db8::1234:333/db',
          DJANGO_POSTGRES,
          'db',
-         'host1,22.55.44.88,[2001:db8::1234]',
+         'host1,22.55.44.88,2001:db8::1234',
          'username',
          'p@ss:12,wor:34d',
          '111,222,333'

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ envlist =
     lint
     manifest
     py{39,310,311,312,313}-django{22,30,31,32,40,41,42}
-    py{310,311,312,313}-django{50,51}
+    py{310,311,312,313}-django{50,51,52}
     pypy-django{22,30,31,32}
 
 [gh-actions]


### PR DESCRIPTION
## Closes [Officially support Django 5.2 on PyPi](https://github.com/joke2k/django-environ/issues/560)

## Django:
- Add support for Django 5.2