### PR TITLE
docs: Fix typo in tips.rst

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -290,7 +290,7 @@ The following example demonstrates the above:
 Proxy value
 ===========
 
-Values that being with a ``$`` may be interpolated. Pass ``interpolate=True`` to
+Values that begin with a ``$`` may be interpolated. Pass ``interpolate=True`` to
 ``environ.Env()`` to enable this feature:
 
 .. code-block:: python


### PR DESCRIPTION
This PR corrects a minor grammatical error in the documentation.

In `docs/tips.rst`, the word "being" was used incorrectly and has been changed to "begin" for clarity.

Before:

"Values that being with a $ may be interpolated."

After:

"Values that begin with a $ may be interpolated."