### PR TITLE
feat(db): add per-option casting for DB URL query options

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -128,6 +128,27 @@ For more detailed example see ":ref:`complex_dict_format`".
       SQLite connects to file based databases. URL schemas ``sqlite://`` or
       ``sqlite://:memory:`` means the database is in the memory (not a file on disk).
 
+Query option casting for ``db_url``
+-----------------------------------
+
+You can cast specific query-string-derived database ``OPTIONS`` using
+``options_cast``.
+
+.. code-block:: python
+
+   import environ
+
+   env = environ.Env()
+   config = env.db_url(
+       options_cast={
+           "ssl": bool,
+           "reconnect": bool,
+       }
+   )
+
+Only mapped keys are cast with the provided type/callable. Unmapped options
+keep the default parsing behavior.
+
 
 .. _environ-env-cache-url:
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -369,6 +369,37 @@ def test_database_options_parsing():
     }
 
 
+def test_database_options_parsing_with_specific_cast():
+    url = (
+        'mysql://user:pass@host:1234/dbname?'
+        'reconnect=true&init_command=SET storage_engine=INNODB&connect_timeout=10'
+    )
+    url = Env.db_url_config(url, options_cast={'reconnect': bool})
+    assert url['OPTIONS'] == {
+        'reconnect': True,
+        'init_command': 'SET storage_engine=INNODB',
+        'connect_timeout': 10,
+    }
+
+
+def test_database_options_parsing_with_db_url_specific_cast():
+    env = Env()
+    env.ENVIRON['DATABASE_URL'] = 'mysql://user:pass@host:1234/dbname?ssl=true'
+    url = env.db_url(options_cast={'ssl': bool})
+    assert url['OPTIONS'] == {
+        'ssl': True,
+    }
+
+
+def test_database_options_parsing_without_specific_cast():
+    url = 'mysql://user:pass@host:1234/dbname?reconnect=true&ssl=true'
+    url = Env.db_url_config(url)
+    assert url['OPTIONS'] == {
+        'reconnect': 'true',
+        'ssl': 'true',
+    }
+
+
 def test_unknown_engine_warns_and_returns_empty_dict(recwarn):
     result = Env.db_url_config('localhost')
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -400,6 +400,18 @@ def test_database_options_parsing_without_specific_cast():
     }
 
 
+def test_database_options_parsing_with_callable_specific_cast():
+    url = 'mysql://user:pass@host:1234/dbname?ssl=true&retry_count=2'
+    url = Env.db_url_config(
+        url,
+        options_cast={'ssl': lambda value: value.upper()},
+    )
+    assert url['OPTIONS'] == {
+        'ssl': 'TRUE',
+        'retry_count': 2,
+    }
+
+
 def test_unknown_engine_warns_and_returns_empty_dict(recwarn):
     result = Env.db_url_config('localhost')
 


### PR DESCRIPTION
## Summary
- add `options_cast` to `Env.db_url()` and `Env.db_url_config()`
- support per-option caster/type mapping for query-string-derived `DATABASES['default']['OPTIONS']`
- keep backward-compatible default behavior for unmapped options
- add regression tests for typed bool casting and legacy behavior

## Why
Some backends need option-specific casting (for example booleans) instead of generic casting behavior.

## Validation
- `tox -e py312-django51 -- tests/test_db.py::test_database_options_parsing tests/test_db.py::test_database_options_parsing_with_specific_cast tests/test_db.py::test_database_options_parsing_with_db_url_specific_cast tests/test_db.py::test_database_options_parsing_without_specific_cast tests/test_db.py::test_db_parsing[cleardb]`

Closes #59