### PR TITLE
fix(read_env): support shell-quoted single-token values

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -1089,7 +1089,22 @@ class Env:
                 # Parse shell-quoted single-token values, such as:
                 # "Tom"="Jerry" or shlex.quote() output with "'\"'\"'" chunks.
                 parsed_single = None
-                if (not parse_comments) and ('"' in val or "'" in val):
+                val_stripped = val.strip()
+                is_json_object = (
+                    val_stripped.startswith('{') and val_stripped.endswith('}')
+                )
+                looks_like_quoted_assignment = (
+                    '=' in val and ('"' in val or "'" in val)
+                )
+                has_shell_quote_chunks = (
+                    '"\'"\'"' in val or "'\"'\"'" in val
+                )
+                if (
+                        not parse_comments
+                        and not is_json_object
+                        and (looks_like_quoted_assignment
+                             or has_shell_quote_chunks)
+                ):
                     try:
                         parts = shlex.split(val, comments=parse_comments)
                     except ValueError:
@@ -1119,13 +1134,13 @@ class Env:
                         if m2a:
                             val = m2a.group(1)
 
-                    # Look for value in double quotes
-                    m3 = re.match(r'\A"(.*)"\Z', val)
-                    if m3:
-                        val = re.sub(
-                            r'\\(.)', _keep_escaped_format_characters,
-                            m3.group(1)
-                        )
+                # Look for value in double quotes
+                m3 = re.match(r'\A"(.*)"\Z', val)
+                if m3:
+                    val = re.sub(
+                        r'\\(.)', _keep_escaped_format_characters,
+                        m3.group(1)
+                    )
 
                 overrides[key] = str(val)
             elif not line or line.startswith('#'):

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -1015,6 +1015,7 @@ class Env:
         return config
 
     @classmethod
+    # pylint: disable=too-many-statements
     def read_env(cls, env_file=None, overwrite=False, parse_comments=False,
                  encoding='utf8', **overrides):
         r"""Read a .env file into os.environ.

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -17,6 +17,7 @@ import itertools
 import logging
 import os
 import re
+import shlex
 import sys
 import warnings
 from typing import Dict, List, Tuple, Union
@@ -1085,7 +1086,20 @@ class Env:
                 # val:  abc#def
                 key, val = m1.group(1), m1.group(2)
 
-                if not parse_comments:
+                # Parse shell-quoted single-token values, such as:
+                # "Tom"="Jerry" or shlex.quote() output with "'\"'\"'" chunks.
+                parsed_single = None
+                if (not parse_comments) and ('"' in val or "'" in val):
+                    try:
+                        parts = shlex.split(val, comments=parse_comments)
+                    except ValueError:
+                        parts = None
+                    if parts and len(parts) == 1:
+                        parsed_single = parts[0]
+
+                if parsed_single is not None:
+                    val = parsed_single
+                elif not parse_comments:
                     # Default behavior
                     #
                     # Look for value in single quotes
@@ -1105,11 +1119,13 @@ class Env:
                         if m2a:
                             val = m2a.group(1)
 
-                # Look for value in double quotes
-                m3 = re.match(r'\A"(.*)"\Z', val)
-                if m3:
-                    val = re.sub(r'\\(.)', _keep_escaped_format_characters,
-                                 m3.group(1))
+                    # Look for value in double quotes
+                    m3 = re.match(r'\A"(.*)"\Z', val)
+                    if m3:
+                        val = re.sub(
+                            r'\\(.)', _keep_escaped_format_characters,
+                            m3.group(1)
+                        )
 
                 overrides[key] = str(val)
             elif not line or line.startswith('#'):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -110,15 +110,15 @@ def test_read_env_keeps_json_object_value_for_json_cast():
         env_path = os.path.join(temp_dir, '.env')
 
         with open(env_path, 'w') as f:
-            f.write('MY_JSON={"a":"b"}\n')
+            f.write('MY_JSON={"a":"b=c"}\n')
             f.flush()
 
             env = Env()
             Env.ENVIRON = {}
             env.read_env(env_path)
 
-            assert env('MY_JSON') == '{"a":"b"}'
-            assert env.json('MY_JSON') == {'a': 'b'}
+            assert env('MY_JSON') == '{"a":"b=c"}'
+            assert env.json('MY_JSON') == {'a': 'b=c'}
 
     os.environ = old_environ
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -80,6 +80,29 @@ def test_parse_comments(variable, value, raw_value, parse_comments):
     os.environ = old_environ
 
 
+def test_read_env_parses_shell_quoted_single_token_values():
+    old_environ = os.environ
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        env_path = os.path.join(temp_dir, '.env')
+
+        with open(env_path, 'w') as f:
+            f.write('MY_DICTIONARY="Tom"="Jerry"\n')
+            f.write("MY_OTHER_DICTIONARY='Tom'='Jerry'\n")
+            f.write('MYTEST=\'Hello\'"\'"\'World\'\n')
+            f.flush()
+
+            env = Env()
+            Env.ENVIRON = {}
+            env.read_env(env_path)
+
+            assert env.dict('MY_DICTIONARY') == {'Tom': 'Jerry'}
+            assert env.dict('MY_OTHER_DICTIONARY') == {'Tom': 'Jerry'}
+            assert env('MYTEST') == "Hello'World"
+
+    os.environ = old_environ
+
+
 class TestEnv:
     def setup_method(self, method):
         """

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -103,6 +103,26 @@ def test_read_env_parses_shell_quoted_single_token_values():
     os.environ = old_environ
 
 
+def test_read_env_keeps_json_object_value_for_json_cast():
+    old_environ = os.environ
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        env_path = os.path.join(temp_dir, '.env')
+
+        with open(env_path, 'w') as f:
+            f.write('MY_JSON={"a":"b"}\n')
+            f.flush()
+
+            env = Env()
+            Env.ENVIRON = {}
+            env.read_env(env_path)
+
+            assert env('MY_JSON') == '{"a":"b"}'
+            assert env.json('MY_JSON') == {'a': 'b'}
+
+    os.environ = old_environ
+
+
 class TestEnv:
     def setup_method(self, method):
         """


### PR DESCRIPTION
## Summary
- fix `Env.read_env()` parsing for shell-quoted single-token values (for example `"Tom"="Jerry"` and `shlex.quote` style chunks)
- preserve existing `parse_comments` behavior
- add regression test for dictionary-style quoted values and `shlex.quote()` style input

## Why
Issue #165 reports malformed parsing when loading `.env` values that contain quoted `=` segments or shell-escaped quote chunks.

## Validation
- `tox -e py312-django51 -- tests/test_env.py::test_parse_comments tests/test_env.py::test_read_env_parses_shell_quoted_single_token_values`
- `tox -e py312-django51 -- tests/test_env.py`

Closes #165