### PR TITLE
Fix Redis unix socket cache URL db placement

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -744,6 +744,8 @@ class Env:
         if url.scheme not in cls.CACHE_SCHEMES:
             raise ImproperlyConfigured(f'Invalid cache schema {url.scheme}')
 
+        parsed_query = parse_qs(url.query) if url.query else {}
+
         location = url.netloc.split(',')
         if len(location) == 1:
             location = location[0]
@@ -783,10 +785,12 @@ class Env:
             else:
                 config['LOCATION'] = locations
 
+            cls._redis_set_db_in_location(config, url, parsed_query, locations)
+
         if backend:
             config['BACKEND'] = backend
 
-        if url.query:
+        if parsed_query:
             config_options = {}
             # Django Redis cache backend expects options in lower case
             # while "django_redis" expects them in upper case
@@ -796,7 +800,7 @@ class Env:
             else:
                 key_modifier = 'upper'
 
-            for k, v in parse_qs(url.query).items():
+            for k, v in parsed_query.items():
                 key = getattr(k, key_modifier)()
                 opt = {key: _cast(v[0])}
                 if k.upper() in cls._CACHE_BASE_OPTIONS:
@@ -806,6 +810,25 @@ class Env:
             config['OPTIONS'] = config_options
 
         return config
+
+    @classmethod
+    def _redis_set_db_in_location(cls, config, url, parsed_query, locations):
+        if url.hostname:
+            return
+        db_values = None
+        for key in tuple(parsed_query):
+            if key.lower() == 'db':
+                db_values = parsed_query.pop(key)
+                break
+        if not db_values:
+            return
+        db_suffix = f'?db={db_values[0]}'
+        if len(locations) == 1:
+            config['LOCATION'] = f'{config["LOCATION"]}{db_suffix}'
+        else:
+            config['LOCATION'] = [
+                f'{location}{db_suffix}' for location in locations
+            ]
 
     @classmethod
     def email_url_config(cls, url, backend=None):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -185,17 +185,17 @@ def test_redis_parsing(redis_driver, client_class_key, password_key):
         }
 
 
-@pytest.mark.parametrize('redis_driver,db_key',
+@pytest.mark.parametrize('redis_driver,client_class_key',
     [
-        ('django.core.cache.backends.redis.RedisCache', 'db'),
-        ('django_redis.cache.RedisCache', 'DB'),
+        ('django.core.cache.backends.redis.RedisCache', 'client_class'),
+        ('django_redis.cache.RedisCache', 'CLIENT_CLASS'),
     ],
     ids=[
         'django',
         'django_redis',
     ],
 )
-def test_redis_socket_url(redis_driver, db_key):
+def test_redis_socket_url(redis_driver, client_class_key):
     mocked_cache_schemes = Env.CACHE_SCHEMES.copy()
     mocked_cache_schemes.update({
         'rediscache': redis_driver,
@@ -203,13 +203,14 @@ def test_redis_socket_url(redis_driver, db_key):
         'rediss': redis_driver,
     })
     with mock.patch.object(Env, 'CACHE_SCHEMES', mocked_cache_schemes):
-        url = 'redis://:redispass@/path/to/socket.sock?db=0'
+        url = ('redis://:redispass@/path/to/socket.sock?db=0'
+               '&client_class=django_redis.client.DefaultClient')
         url = Env.cache_url_config(url)
 
         assert url['BACKEND'] == redis_driver
-        assert url['LOCATION'] == 'unix://:redispass@/path/to/socket.sock'
+        assert url['LOCATION'] == 'unix://:redispass@/path/to/socket.sock?db=0'
         assert url['OPTIONS'] == {
-            db_key: 0
+            client_class_key: 'django_redis.client.DefaultClient'
         }
 
 


### PR DESCRIPTION
## Summary
- move `db` query parameter into `LOCATION` for Redis unix socket cache URLs
- keep non-`db` query parameters in `OPTIONS` with backend-specific key casing unchanged
- add/adjust cache tests to validate unix socket URL keeps `?db=` in final location

## Validation
- `tox -e py312-django51 -- tests/test_cache.py`
- `tox -e lint`
- `tox -e coverage-report`
- previously focused checks: `tox -e py312-django51 -- tests/test_cache.py::test_redis_socket_url tests/test_cache.py::test_redis_parsing`

Closes: #226 and #244 