### PR TITLE
Add db_url extra_options support for PostgreSQL pool settings

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -174,6 +174,21 @@ If a value needs explicit typing (for example booleans or JSON), use
 Only mapped keys are cast with the provided type/callable. Unmapped options
 keep the default parsing behavior.
 
+For values that are not practical to pass in a URL query string (for example
+nested dictionaries like Django 5.1 PostgreSQL ``pool`` options), pass
+``extra_options`` and they will be merged into ``OPTIONS``:
+
+.. code-block:: python
+
+   config = environ.Env.db_url_config(
+       "postgres://user:password@host:5432/dbname",
+       extra_options={
+           "pool": {"min_size": 2, "max_size": 4, "timeout": 10},
+       },
+   )
+
+   # {"OPTIONS": {"pool": {"min_size": 2, "max_size": 4, "timeout": 10}}}
+
 .. _environ-env-cache-url:
 
 ``environ.Env.cache_url``

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -332,6 +332,7 @@ class Env:
             parse_default=True
         )
 
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def db_url(
             self,
             var=DEFAULT_DATABASE_ENV,
@@ -351,6 +352,7 @@ class Env:
             options_cast=options_cast,
             extra_options=extra_options,
         )
+    # pylint: enable=too-many-arguments,too-many-positional-arguments
 
     db = db_url
 

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -337,7 +337,8 @@ class Env:
             var=DEFAULT_DATABASE_ENV,
             default=NOTSET,
             engine=None,
-            options_cast=None) -> Dict:
+            options_cast=None,
+            extra_options=None) -> Dict:
         """Returns a config dictionary, defaulting to DATABASE_URL.
 
         The db method is an alias for db_url.
@@ -347,7 +348,8 @@ class Env:
         return self.db_url_config(
             self.get_value(var, default=default),
             engine=engine,
-            options_cast=options_cast
+            options_cast=options_cast,
+            extra_options=extra_options,
         )
 
     db = db_url
@@ -577,7 +579,8 @@ class Env:
 
     @classmethod
     # pylint: disable=too-many-statements
-    def db_url_config(cls, url, engine=None, options_cast=None):
+    def db_url_config(cls, url, engine=None, options_cast=None,
+                      extra_options=None):
         # pylint: enable-msg=too-many-statements
         """Parse an arbitrary database URL.
 
@@ -603,6 +606,9 @@ class Env:
         :param dict|None options_cast:
             Optional per-option cast mapping for query-string-derived
             ``OPTIONS`` values. Unmapped options keep default casting behavior.
+        :param dict|None extra_options:
+            Optional dictionary merged into ``OPTIONS`` after URL parsing.
+            Values in ``extra_options`` override query-string ``OPTIONS``.
         :return: Parsed database URL.
         :rtype: dict
         """
@@ -710,6 +716,9 @@ class Env:
                         k: cls._cast_db_option(k, v[0], options_cast)
                     })
             config['OPTIONS'] = config_options
+        if extra_options:
+            config.setdefault('OPTIONS', {})
+            config['OPTIONS'].update(extra_options)
 
         if engine:
             config['ENGINE'] = engine

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -413,6 +413,17 @@ def test_database_options_parsing_with_extra_options_override():
     }
 
 
+def test_database_extra_options_are_not_cast():
+    url = 'mysql://user:pass@host:1234/dbname?ssl=true'
+    url = Env.db_url_config(
+        url,
+        options_cast={'ssl': bool},
+        extra_options={'ssl': 'false'},
+    )
+    assert url['OPTIONS']['ssl'] == 'false'
+    assert isinstance(url['OPTIONS']['ssl'], str)
+
+
 def test_database_options_parsing_without_specific_cast():
     url = 'mysql://user:pass@host:1234/dbname?reconnect=true&ssl=true'
     url = Env.db_url_config(url)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -391,6 +391,28 @@ def test_database_options_parsing_with_db_url_specific_cast():
     }
 
 
+def test_database_options_parsing_with_db_url_extra_options():
+    env = Env()
+    env.ENVIRON['DATABASE_URL'] = 'postgres://user:pass@host:1234/dbname'
+    url = env.db_url(extra_options={
+        'pool': {'min_size': 2, 'max_size': 4, 'timeout': 10},
+    })
+    assert url['OPTIONS'] == {
+        'pool': {'min_size': 2, 'max_size': 4, 'timeout': 10},
+    }
+
+
+def test_database_options_parsing_with_extra_options_override():
+    url = 'postgres://user:pass@host:1234/dbname?pool=disabled&sslmode=require'
+    url = Env.db_url_config(url, extra_options={
+        'pool': {'min_size': 2, 'max_size': 4, 'timeout': 10},
+    })
+    assert url['OPTIONS'] == {
+        'pool': {'min_size': 2, 'max_size': 4, 'timeout': 10},
+        'sslmode': 'require',
+    }
+
+
 def test_database_options_parsing_without_specific_cast():
     url = 'mysql://user:pass@host:1234/dbname?reconnect=true&ssl=true'
     url = Env.db_url_config(url)


### PR DESCRIPTION
## Summary
- add `extra_options` to `Env.db_url` and `Env.db_url_config`
- merge `extra_options` into `OPTIONS` after URL parsing (override same keys)
- add tests for nested pool options and override behavior
- document the new usage in `docs/types.rst`

Closes #530