### PR TITLE
Remove compat usage of `simplejson`

### DIFF
--- a/environ/compat.py
+++ b/environ/compat.py
@@ -11,11 +11,6 @@
 
 from importlib.util import find_spec
 
-if find_spec('simplejson'):
-    import simplejson as json
-else:
-    import json
-
 if find_spec('django'):
     from django import VERSION as DJANGO_VERSION
     from django.core.exceptions import ImproperlyConfigured

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -14,6 +14,7 @@ variables to configure your Django application.
 
 import ast
 import itertools
+import json
 import logging
 import os
 import re
@@ -33,7 +34,6 @@ from urllib.parse import (
 from .compat import (
     DJANGO_POSTGRES,
     ImproperlyConfigured,
-    json,
     PYMEMCACHE_DRIVER,
     REDIS_DRIVER,
 )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,7 +7,7 @@
 # For the full copyright and license information, please view
 # the LICENSE.txt file that was distributed with this source code.
 
-from environ.compat import json
+import json
 
 
 class FakeEnv:


### PR DESCRIPTION
The minimum Python version is now 3.9, which always has a `json` module.