### PR TITLE
Add type checking with MyPy to tests

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Lint with tox
         run: tox -e lint
+
+      - name: Check types with tox
+        run: tox -e type

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -21,6 +21,7 @@ import re
 import shlex
 import sys
 import warnings
+from collections.abc import MutableMapping
 from typing import Dict, List, Tuple, Union
 from urllib.parse import (
     parse_qs,
@@ -109,7 +110,7 @@ class Env:
         SMTP_LOGIN = env('SMTP_LOGIN')
     """
 
-    ENVIRON = os.environ
+    ENVIRON: MutableMapping = os.environ
     NOTSET = NoValue()
     BOOLEAN_TRUE_STRINGS = ('true', 'on', 'ok', 'y', 'yes', '1')
     URL_CLASS = ParseResult

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.mypy]
+files = [
+  "environ",
+  "tests",
+]
+#check_untyped_defs = true
+show_error_codes = true
+#strict = true
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
     linkcheck
     docs
     lint
+    type
     manifest
     py{39,310,311,312,313}-django{22,30,31,32,40,41,42}
     py{310,311,312,313}-django{50,51}
@@ -91,6 +92,13 @@ commands =
         --disable=too-many-public-methods \
         --disable=too-many-lines \
         environ
+
+[testenv:type]
+deps =
+    mypy
+    django-stubs
+commands =
+    mypy {posargs}
 
 [testenv:linkcheck]
 description = Check external links in the package documentation


### PR DESCRIPTION
This also adds a `py.typed` file, which is mandatory to allow downstream packages to read any type information from this project: https://peps.python.org/pep-0561/