### PR TITLE
Add a direct dependency on Django >= 2.2

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -340,7 +340,7 @@ Restrict string values with choices
 
 You can restrict ``env.str()`` to an allowed list of values using
 ``choices``. If the value is not in the provided list,
-``ImproperlyConfigured`` is raised.
+``ImproperlyConfigured`` is raised.django.core.exceptions
 
 .. code-block:: python
 

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -340,7 +340,7 @@ Restrict string values with choices
 
 You can restrict ``env.str()`` to an allowed list of values using
 ``choices``. If the value is not in the provided list,
-``ImproperlyConfigured`` is raised.django.core.exceptions
+``django.core.exceptions.ImproperlyConfigured`` is raised.
 
 .. code-block:: python
 

--- a/environ/compat.py
+++ b/environ/compat.py
@@ -11,14 +11,7 @@
 
 from importlib.util import find_spec
 
-if find_spec('django'):
-    from django import VERSION as DJANGO_VERSION
-    from django.core.exceptions import ImproperlyConfigured
-else:
-    DJANGO_VERSION = None
-
-    class ImproperlyConfigured(Exception):
-        """Django is somehow improperly configured"""
+import django
 
 
 def choose_rediscache_driver():
@@ -29,7 +22,7 @@ def choose_rediscache_driver():
         return 'django_redis.cache.RedisCache'
 
     # use built-in support if Django 4+
-    if DJANGO_VERSION is not None and DJANGO_VERSION >= (4, 0):
+    if django.VERSION >= (4, 0):
         return 'django.core.cache.backends.redis.RedisCache'
 
     # back compatibility with redis_cache package
@@ -38,15 +31,12 @@ def choose_rediscache_driver():
 
 def choose_postgres_driver():
     """Backward compatibility for postgresql driver."""
-    old_django = DJANGO_VERSION is not None and DJANGO_VERSION < (2, 0)
-    if old_django:
-        return 'django.db.backends.postgresql_psycopg2'
     return 'django.db.backends.postgresql'
 
 
 def choose_pymemcache_driver():
     """Backward compatibility for pymemcache."""
-    old_django = DJANGO_VERSION is not None and DJANGO_VERSION < (3, 2)
+    old_django = django.VERSION < (3, 2)
     if old_django or not find_spec('pymemcache'):
         # The original backend choice for the 'pymemcache' scheme is
         # unfortunately 'pylibmc'.

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -31,9 +31,10 @@ from urllib.parse import (
     urlunparse,
 )
 
+from django.core.exceptions import ImproperlyConfigured
+
 from .compat import (
     DJANGO_POSTGRES,
-    ImproperlyConfigured,
     PYMEMCACHE_DRIVER,
     REDIS_DRIVER,
 )

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,9 @@ CLASSIFIERS = [
 ]
 
 # Dependencies that are downloaded by pip on installation and why.
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = [
+    'django>=2.2',
+]
 
 DEPENDENCY_LINKS = []
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -10,11 +10,12 @@
 from unittest import mock
 
 import pytest
+import django
+from django.core.exceptions import ImproperlyConfigured
 
 import environ.compat
 from environ import Env
 from environ.compat import (
-    ImproperlyConfigured,
     PYMEMCACHE_DRIVER,
     REDIS_DRIVER,
 )
@@ -121,12 +122,12 @@ def test_cache_parsing(url, backend, location):
     assert url['LOCATION'] == location
 
 
-@pytest.mark.parametrize('django_version', ((3, 2), (3, 1), None))
+@pytest.mark.parametrize('django_version', ((3, 2), (3, 1)))
 @pytest.mark.parametrize('pymemcache_installed', (True, False))
 def test_pymemcache_compat(django_version, pymemcache_installed):
     old = 'django.core.cache.backends.memcached.PyLibMCCache'
     new = 'django.core.cache.backends.memcached.PyMemcacheCache'
-    with mock.patch.object(environ.compat, 'DJANGO_VERSION', django_version):
+    with mock.patch.object(django, 'VERSION', django_version):
         with mock.patch('environ.compat.find_spec') as mock_find_spec:
             mock_find_spec.return_value = pymemcache_installed
             driver = environ.compat.choose_pymemcache_driver()
@@ -136,14 +137,14 @@ def test_pymemcache_compat(django_version, pymemcache_installed):
                 assert driver == new if pymemcache_installed else old
 
 
-@pytest.mark.parametrize('django_version', ((4, 0), (3, 2), None))
+@pytest.mark.parametrize('django_version', ((4, 0), (3, 2)))
 @pytest.mark.parametrize('django_redis_installed', (True, False))
 def test_rediscache_compat(django_version, django_redis_installed):
     django_new = 'django.core.cache.backends.redis.RedisCache'
     redis_cache = 'redis_cache.RedisCache'
     django_redis = 'django_redis.cache.RedisCache'
 
-    with mock.patch.object(environ.compat, 'DJANGO_VERSION', django_version):
+    with mock.patch.object(django, 'VERSION', django_version):
         with mock.patch('environ.compat.find_spec') as mock_find_spec:
             mock_find_spec.return_value = django_redis_installed
             driver = environ.compat.choose_rediscache_driver()

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -9,7 +9,7 @@
 
 from environ import Env
 import pytest
-from environ.compat import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured
 
 
 def test_channels_parsing():

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -7,9 +7,10 @@
 # For the full copyright and license information, please view
 # the LICENSE.txt file that was distributed with this source code.
 
-from environ import Env
-from environ.compat import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured
 import pytest
+
+from environ import Env
 
 
 def test_smtp_parsing():

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -15,12 +15,12 @@ import io
 import warnings
 from urllib.parse import quote
 
+from django.core.exceptions import ImproperlyConfigured
 import pytest
 
 from environ import DefaultValueWarning, Env, Path
 from environ.compat import (
     DJANGO_POSTGRES,
-    ImproperlyConfigured,
     REDIS_DRIVER,
 )
 from .asserts import assert_type_and_value

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -10,11 +10,10 @@
 import os
 import sys
 
+from django.core.exceptions import ImproperlyConfigured
 import pytest
 
-
 from environ import Path
-from environ.compat import ImproperlyConfigured
 
 
 def test_str(volume):


### PR DESCRIPTION
This ensures that the `ImproperlyConfigured` exception is actually the one from Django, not one with the same name but a different identity.

Also, the `django.VERSION` has been available since Django 2.2, so remove the assumption that it could be `None`.

Finally, remove some code for supporting versions of Django<2.2.