### PR TITLE
fix: add interpolate flag to allow disabling proxy resolution

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -361,19 +361,29 @@ You can restrict ``env.str()`` to an allowed list of values using
 Proxy value
 ===========
 
-Values that begin with a ``$`` may be interpolated. Pass ``interpolate=True`` to
-``environ.Env()`` to enable this feature:
+Values that begin with a ``$`` may be interpolated. This feature is enabled by
+default:
 
 .. code-block:: python
 
    import environ
 
-   env = environ.Env(interpolate=True)
+   env = environ.Env()
 
    # BAR=FOO
    # PROXY=$BAR
-   >>> print(env.str('PROXY'))
-   FOO
+   assert env.str('PROXY') == 'FOO'
+
+To disable proxy interpolation and read the raw value instead, set
+``env.interpolate = False``:
+
+.. code-block:: python
+
+   env = environ.Env()
+   env.interpolate = False
+
+   # PROXY=$BAR
+   assert env.str('PROXY') == '$BAR'
 
 
 Escape Proxy

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -224,6 +224,7 @@ class Env:
     def __init__(self, **scheme):
         self.smart_cast = True
         self.escape_proxy = False
+        self.interpolate = True
         self.warn_on_default = False
         self.prefix = ""
         self.scheme = scheme
@@ -495,7 +496,8 @@ class Env:
         # Resolve any proxied values
         prefix = b'$' if isinstance(value, bytes) else '$'
         escape = rb'\$' if isinstance(value, bytes) else r'\$'
-        if hasattr(value, 'startswith') and value.startswith(prefix):
+        if self.interpolate and \
+                hasattr(value, 'startswith') and value.startswith(prefix):
             value = value.lstrip(prefix)
             value = self.get_value(value, cast=cast, default=default)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -233,6 +233,10 @@ class TestEnv:
     def test_proxied_value(self):
         assert self.env('PROXIED_VAR') == 'bar'
 
+    def test_proxied_value_interpolate_disabled(self):
+        self.env.interpolate = False
+        assert self.env('PROXIED_VAR') == '$STR_VAR'
+
     def test_escaped_dollar_sign(self):
         self.env.escape_proxy = True
         assert self.env('ESCAPED_VAR') == '$baz'


### PR DESCRIPTION
## Summary
- Adds an `interpolate` attribute to `Env` (defaults to `True`) that controls whether values starting with `$` are resolved as proxy variables
- Guards the proxy resolution block in `get_value()` with `self.interpolate`, allowing users to retrieve raw `$`-prefixed values
- Adds test for the new behavior

## Context
Values starting with `$` were always resolved as proxy variables with no way to disable this behavior. Setting `interpolate=False` (as documented) had no effect because the parameter was silently absorbed into the `scheme` dict.

Fixes #525

## Test plan
- [x] Existing `test_proxied_value` still passes (interpolation on by default)
- [x] New `test_proxied_value_interpolate_disabled` verifies raw value returned when `interpolate = False`
- [x] Existing `test_escaped_dollar_sign` and `test_escaped_dollar_sign_disabled` still pass
- [x] Full test suite (450 tests) passes