### PR TITLE
Update README.rst to reflect the Django's use of pathlib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,15 +41,15 @@ environment variables obtained from an environment file and provided by the OS:
 .. code-block:: python
 
    import environ
-   import os
+   from pathlib import Path
 
    env = environ.Env(
        # set casting, default value
        DEBUG=(bool, False)
    )
 
-   # Set the project base directory
-   BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+   # Build paths inside the project like this: BASE_DIR / 'subdir'.
+   BASE_DIR = Path(__file__).resolve().parent.parent
 
    # Take environment variables from .env file
    environ.Env.read_env(os.path.join(BASE_DIR, '.env'))

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ environment variables obtained from an environment file and provided by the OS:
    BASE_DIR = Path(__file__).resolve().parent.parent
 
    # Take environment variables from .env file
-   environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
+   environ.Env.read_env(BASE_DIR / '.env')
 
    # False if not in os.environ because of casting above
    DEBUG = env('DEBUG')


### PR DESCRIPTION
This is a very simple but also important update to the README.rst. New users of Django are not used to seeing:
```python
import os
``` 
The updated use of pathlib was officially added in Django 3.1
```python
from pathlib import Path 
```
