### PR TITLE
feat(typing): ship PEP 561 py.typed marker (#567)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,10 @@
 include *.rst LICENSE.txt *.yml
 graft .github
 
+# PEP 561 marker so mypy/pyright pick up the inline type hints shipped
+# in environ/environ.py (cf. #567).
+include environ/py.typed
+
 # The contents of the directory tree tests will first be added to the sdist.
 # Many OS distributions prefers provide an ability run the tests
 # during the package installation.

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -103,6 +103,24 @@ def test_read_env_parses_shell_quoted_single_token_values():
     os.environ = old_environ
 
 
+def test_pep561_py_typed_marker_is_shipped():
+    """Regression test for #567 (PEP 561 marker).
+
+    Static type checkers (mypy, pyright/Pylance, pyre, ...) only honour
+    inline type hints if the package ships a ``py.typed`` marker file
+    inside its top-level distribution. Without it, downstream code gets
+    ``import-untyped`` errors even though django-environ has had inline
+    annotations since #546.
+    """
+    import environ as environ_pkg
+    pkg_dir = os.path.dirname(environ_pkg.__file__)
+    marker = os.path.join(pkg_dir, 'py.typed')
+    assert os.path.isfile(marker), (
+        f"Expected PEP 561 marker at {marker}; without it, downstream "
+        "mypy/pyright users do not see django-environ's inline type hints."
+    )
+
+
 def test_read_env_keeps_json_object_value_for_json_cast():
     old_environ = os.environ
 


### PR DESCRIPTION
## Summary

Inline type hints have been part of `environ/environ.py` since #546 (commit `dd4d308`), but external mypy, pyright/Pylance, and pyre users still get `import-untyped` errors because the distribution does not advertise itself as typed. [PEP 561](https://peps.python.org/pep-0561/) requires a `py.typed` marker file placed at the package root; once it's there, downstream type checkers honour the inline annotations.

Fixes #567.

## Context

PEP 561 §3 (Packaging Type Information): a package indicates support for type checking by shipping a marker file named `py.typed` in the package directory. Without it, mypy emits `[import-untyped]` even if every `.py` file is fully annotated.

The setup is already typed-friendly (`include_package_data=True`, `zip_safe=False`), so we only need to:

1. Create the marker `environ/py.typed` (empty file is fine per the PEP)
2. Add an explicit `include environ/py.typed` line to `MANIFEST.in` so the marker lands in the sdist as well as the wheel (`include_package_data` reads `MANIFEST.in` for sdist content)

## Changes

- `environ/py.typed` — new empty marker file
- `MANIFEST.in` — explicit `include environ/py.typed` with a short comment pointing at #567 for future readers
- `tests/test_env.py` — `test_pep561_py_typed_marker_is_shipped` asserts the marker is co-located with the imported package, with an actionable error message

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/joke2k/django-environ.git /tmp/dj-environ-567 \
  && cd /tmp/dj-environ-567
python3 -m venv .venv && . .venv/bin/activate
pip install -e ".[testing]" build mypy >/dev/null

# --- BEFORE: origin/develop, expect missing marker ---
git checkout origin/develop -- environ/ MANIFEST.in
python3 -m build --wheel --outdir /tmp/dist-before >/dev/null 2>&1
unzip -l /tmp/dist-before/django_environ-*.whl | grep -E 'py.typed' || echo "MISSING py.typed in wheel"
# Expected: "MISSING py.typed in wheel"
echo 'import environ; e = environ.Env(); s: str = e.str("X", "y")' > /tmp/typetest.py
mypy /tmp/typetest.py 2>&1 | tail -3
# Expected: error mentioning "library stubs or py.typed marker"

# --- AFTER: this branch, expect marker present + mypy happy ---
git fetch https://github.com/jbbqqf/django-environ.git feat/567-pep561-py-typed
git checkout FETCH_HEAD -- environ/ MANIFEST.in tests/
python3 -m build --sdist --wheel --outdir /tmp/dist-after >/dev/null 2>&1
unzip -l /tmp/dist-after/django_environ-*.whl | grep py.typed
# Expected: line ending in "environ/py.typed"
tar tzf /tmp/dist-after/django_environ-*.tar.gz | grep py.typed
# Expected: ".../environ/py.typed"
pip install -e . --quiet --force-reinstall
mypy /tmp/typetest.py 2>&1 | tail -3
# Expected: "Success: no issues found" (or unrelated user-code errors only)

# Regression test:
pytest tests/test_env.py -k pep561 -v
# Expected: 1 passed
```

## What I ran locally

```
$ pytest tests/test_env.py -k pep561 -v
... 1 passed in 0.07s

$ pytest
... 456 passed in 0.25s

$ python -m build --sdist --wheel
... Successfully built django_environ-0.13.0.tar.gz and django_environ-0.13.0-py3-none-any.whl

$ unzip -l dist/django_environ-0.13.0-py3-none-any.whl | grep py.typed
        0  2026-05-22 10:30   environ/py.typed
$ tar tzf dist/django_environ-0.13.0.tar.gz | grep py.typed
django_environ-0.13.0/environ/py.typed
```

The regression test was also verified to FAIL when the marker is temporarily removed: `Expected PEP 561 marker at .../environ/py.typed; without it, downstream mypy/pyright users do not see django-environ's inline type hints.`

## Edge cases

| # | Scenario | Expected | Verified by |
|---|---|---|---|
| 1 | Wheel install | `py.typed` is at `<site-packages>/environ/py.typed` | `unzip -l ...whl \| grep py.typed` |
| 2 | sdist install | `py.typed` is in the tarball | `tar tzf ...tar.gz \| grep py.typed` |
| 3 | Editable install (`pip install -e .`) | `py.typed` is in repo `environ/` | new `test_pep561_py_typed_marker_is_shipped` |
| 4 | mypy on downstream user code | no `import-untyped` error | manual run, expected pass |

## Risk / blast radius

Zero behavioural change. The package gains one empty file at the package root and one extra line in `MANIFEST.in`. Existing 455 tests are unaffected; one new test added.

---

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against django-environ's source and the PEP 561 spec. The reproducer block above is the one I used during development; reviewers can paste it verbatim.*
