### PR TITLE
Add Env.configured factory

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -478,15 +478,27 @@ an existing set environment variable, use the ``overwrite=True`` argument of
    env.read_env(BASE_DIR('.env'), overwrite=True)
 
 
-Create and read an Env in one step
-----------------------------------
+Create a configured Env in one step
+-----------------------------------
 
-Use :meth:`.environ.Env.from_env_file` to create an ``Env`` instance, configure
-its flags, and read an environment file in a single call:
+Use :meth:`.environ.Env.configured` to create an ``Env`` instance and configure
+its flags in a single call:
 
 .. code-block:: python
 
-   env = environ.Env.from_env_file(
+   env = environ.Env.configured(
+       prefix='DJANGO_',
+       smart_cast=False,
+       warn_on_default=True,
+   )
+
+   env.bool('DEBUG', default=False)
+
+Pass an env file path to read it after the instance has been configured:
+
+.. code-block:: python
+
+   env = environ.Env.configured(
        BASE_DIR('.env'),
        overwrite=True,
        parse_comments=True,
@@ -494,14 +506,12 @@ its flags, and read an environment file in a single call:
        smart_cast=False,
    )
 
-   env.bool('DEBUG', default=False)
-
 The regular ``Env`` constructor remains reserved for schema declarations. Pass
-schemas with the ``scheme`` argument when using ``from_env_file``:
+schemas with the ``scheme`` argument when using ``configured``:
 
 .. code-block:: python
 
-   env = environ.Env.from_env_file(
+   env = environ.Env.configured(
        BASE_DIR('.env'),
        scheme={
            'DEBUG': (bool, False),

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -478,6 +478,38 @@ an existing set environment variable, use the ``overwrite=True`` argument of
    env.read_env(BASE_DIR('.env'), overwrite=True)
 
 
+Create and read an Env in one step
+----------------------------------
+
+Use :meth:`.environ.Env.from_env_file` to create an ``Env`` instance, configure
+its flags, and read an environment file in a single call:
+
+.. code-block:: python
+
+   env = environ.Env.from_env_file(
+       BASE_DIR('.env'),
+       overwrite=True,
+       parse_comments=True,
+       prefix='DJANGO_',
+       smart_cast=False,
+   )
+
+   env.bool('DEBUG', default=False)
+
+The regular ``Env`` constructor remains reserved for schema declarations. Pass
+schemas with the ``scheme`` argument when using ``from_env_file``:
+
+.. code-block:: python
+
+   env = environ.Env.from_env_file(
+       BASE_DIR('.env'),
+       scheme={
+           'DEBUG': (bool, False),
+           'DATABASE_URL': str,
+       },
+   )
+
+
 Handling prefixes
 =================
 

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -233,19 +233,20 @@ class Env:
 
     @classmethod
     # pylint: disable=too-many-arguments
-    def from_env_file(
+    def configured(
             cls, env_file=None, scheme=None, *, overwrite=False,
             parse_comments=False, encoding='utf8', smart_cast=True,
             escape_proxy=False, interpolate=True, warn_on_default=False,
             prefix="", **overrides):
-        r"""Create an Env instance and read a .env file.
+        r"""Create a configured Env instance.
 
         This keeps ``Env.__init__`` reserved for schema declarations while
-        making it possible to configure instance flags and load an env file in
-        one step.
+        making it possible to configure instance flags in one step. If
+        ``env_file`` is provided, the file is read after the instance is
+        configured.
 
         :param env_file: The path to the ``.env`` file your application should
-            use.
+            use. When omitted, no env file is read.
         :param scheme: An optional mapping of schema declarations passed to
             ``Env.__init__``.
         :param overwrite: ``overwrite=True`` will force an overwrite of
@@ -267,13 +268,14 @@ class Env:
         env.interpolate = interpolate
         env.warn_on_default = warn_on_default
         env.prefix = prefix
-        env.read_env(
-            env_file,
-            overwrite=overwrite,
-            parse_comments=parse_comments,
-            encoding=encoding,
-            **overrides
-        )
+        if env_file is not None or overrides:
+            env.read_env(
+                env_file,
+                overwrite=overwrite,
+                parse_comments=parse_comments,
+                encoding=encoding,
+                **overrides
+            )
         return env
 
     def __call__(self, var, cast=None, default=NOTSET, parse_default=False):

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -231,6 +231,51 @@ class Env:
         self.prefix = ""
         self.scheme = scheme
 
+    @classmethod
+    # pylint: disable=too-many-arguments
+    def from_env_file(
+            cls, env_file=None, scheme=None, *, overwrite=False,
+            parse_comments=False, encoding='utf8', smart_cast=True,
+            escape_proxy=False, interpolate=True, warn_on_default=False,
+            prefix="", **overrides):
+        r"""Create an Env instance and read a .env file.
+
+        This keeps ``Env.__init__`` reserved for schema declarations while
+        making it possible to configure instance flags and load an env file in
+        one step.
+
+        :param env_file: The path to the ``.env`` file your application should
+            use.
+        :param scheme: An optional mapping of schema declarations passed to
+            ``Env.__init__``.
+        :param overwrite: ``overwrite=True`` will force an overwrite of
+            existing environment variables.
+        :param parse_comments: Determines whether to recognize and ignore
+           inline comments in the .env file. Default is False.
+        :param encoding: The encoding to use when reading the environment file.
+        :param smart_cast: Enable or disable smart casting.
+        :param escape_proxy: Enable or disable escaped proxy values.
+        :param interpolate: Enable or disable proxy value interpolation.
+        :param warn_on_default: Enable or disable warnings for default values.
+        :param prefix: A prefix to prepend to variables read by the instance.
+        :param \**overrides: Any additional keyword arguments provided directly
+            to read_env will be added to the environment.
+        """
+        env = cls(**(scheme or {}))
+        env.smart_cast = smart_cast
+        env.escape_proxy = escape_proxy
+        env.interpolate = interpolate
+        env.warn_on_default = warn_on_default
+        env.prefix = prefix
+        env.read_env(
+            env_file,
+            overwrite=overwrite,
+            parse_comments=parse_comments,
+            encoding=encoding,
+            **overrides
+        )
+        return env
+
     def __call__(self, var, cast=None, default=NOTSET, parse_default=False):
         return self.get_value(
             var,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -595,6 +595,66 @@ class TestEnv:
         assert any('Invalid line: INVALID LINE' in message
                    for message in caplog.messages)
 
+    def test_from_env_file_reads_file_and_configures_flags(self, tmp_path):
+        env_path = tmp_path / '.env'
+        env_path.write_text(
+            'APP_VALUE=42\n'
+            r'APP_ESCAPED=\$APP_VALUE'
+            '\n',
+            encoding='utf-8',
+        )
+
+        env = Env.from_env_file(
+            env_path,
+            scheme={'APP_VALUE': int},
+            overwrite=True,
+            smart_cast=False,
+            escape_proxy=True,
+            interpolate=False,
+            warn_on_default=True,
+            prefix='APP_',
+        )
+
+        assert env('VALUE') == 42
+        assert env('ESCAPED') == '$APP_VALUE'
+        assert not env.smart_cast
+        assert env.escape_proxy
+        assert not env.interpolate
+        assert env.warn_on_default
+        assert env.prefix == 'APP_'
+
+    def test_from_env_file_passes_read_env_options(self, tmp_path):
+        env_path = tmp_path / '.env'
+        env_path.write_text('FROM_ENV_FILE=loaded # comment\n',
+                            encoding='utf-8')
+
+        Env.ENVIRON['FROM_ENV_FILE'] = 'existing'
+
+        env = Env.from_env_file(
+            env_path,
+            overwrite=False,
+            parse_comments=True,
+            FROM_ENV_OVERRIDE='override',
+        )
+        assert env('FROM_ENV_FILE') == 'existing'
+        assert env('FROM_ENV_OVERRIDE') == 'override'
+
+        env = Env.from_env_file(env_path, overwrite=True,
+                                parse_comments=True)
+        assert env('FROM_ENV_FILE') == 'loaded '
+
+    def test_from_env_file_returns_subclass_instance(self, tmp_path):
+        class CustomEnv(Env):
+            pass
+
+        env_path = tmp_path / '.env'
+        env_path.write_text('SUBCLASS_VALUE=value\n', encoding='utf-8')
+
+        env = CustomEnv.from_env_file(env_path, overwrite=True)
+
+        assert isinstance(env, CustomEnv)
+        assert env('SUBCLASS_VALUE') == 'value'
+
 
 class TestFileEnv(TestEnv):
     def setup_method(self, method):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -595,7 +595,7 @@ class TestEnv:
         assert any('Invalid line: INVALID LINE' in message
                    for message in caplog.messages)
 
-    def test_from_env_file_reads_file_and_configures_flags(self, tmp_path):
+    def test_configured_reads_file_and_configures_flags(self, tmp_path):
         env_path = tmp_path / '.env'
         env_path.write_text(
             'APP_VALUE=42\n'
@@ -604,7 +604,7 @@ class TestEnv:
             encoding='utf-8',
         )
 
-        env = Env.from_env_file(
+        env = Env.configured(
             env_path,
             scheme={'APP_VALUE': int},
             overwrite=True,
@@ -623,14 +623,14 @@ class TestEnv:
         assert env.warn_on_default
         assert env.prefix == 'APP_'
 
-    def test_from_env_file_passes_read_env_options(self, tmp_path):
+    def test_configured_passes_read_env_options(self, tmp_path):
         env_path = tmp_path / '.env'
         env_path.write_text('FROM_ENV_FILE=loaded # comment\n',
                             encoding='utf-8')
 
         Env.ENVIRON['FROM_ENV_FILE'] = 'existing'
 
-        env = Env.from_env_file(
+        env = Env.configured(
             env_path,
             overwrite=False,
             parse_comments=True,
@@ -639,18 +639,33 @@ class TestEnv:
         assert env('FROM_ENV_FILE') == 'existing'
         assert env('FROM_ENV_OVERRIDE') == 'override'
 
-        env = Env.from_env_file(env_path, overwrite=True,
-                                parse_comments=True)
+        env = Env.configured(env_path, overwrite=True, parse_comments=True)
         assert env('FROM_ENV_FILE') == 'loaded '
 
-    def test_from_env_file_returns_subclass_instance(self, tmp_path):
+    def test_configured_without_file_only_configures_flags(self):
+        env = Env.configured(
+            smart_cast=False,
+            escape_proxy=True,
+            interpolate=False,
+            warn_on_default=True,
+            prefix='APP_',
+        )
+
+        assert env.scheme == {}
+        assert not env.smart_cast
+        assert env.escape_proxy
+        assert not env.interpolate
+        assert env.warn_on_default
+        assert env.prefix == 'APP_'
+
+    def test_configured_returns_subclass_instance(self, tmp_path):
         class CustomEnv(Env):
             pass
 
         env_path = tmp_path / '.env'
         env_path.write_text('SUBCLASS_VALUE=value\n', encoding='utf-8')
 
-        env = CustomEnv.from_env_file(env_path, overwrite=True)
+        env = CustomEnv.configured(env_path, overwrite=True)
 
         assert isinstance(env, CustomEnv)
         assert env('SUBCLASS_VALUE') == 'value'


### PR DESCRIPTION
## Summary

Adds `Env.configured()` as a class factory that creates an `Env` instance and applies instance flags in one step.

This keeps `Env.__init__` reserved for schema declarations while still allowing callers to pass:

- instance flags: `smart_cast`, `escape_proxy`, `interpolate`, `warn_on_default`, and `prefix`
- schema declarations through the explicit `scheme={...}` argument
- optionally, env file read options: `overwrite`, `parse_comments`, `encoding`, and overrides when an `env_file` is provided

When `env_file` is omitted, `configured()` only configures the instance and does not call `read_env(None)`, avoiding the caller-frame fallback issue raised in review.

The method is implemented as a `classmethod` so subclasses receive an instance of the subclass.

## Documentation

Documented the new helper in `docs/tips.rst` with examples for flag-only configuration, optional env file loading, and schema usage.

## Tests

- `.venv/bin/python -m pytest tests/test_env.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m tox -e lint`