### PR TITLE
Add PEP518 build system metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=71.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.mypy]
 files = [
   "environ",

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,6 @@ EXTRAS_REQUIRE = {
     'testing': [
         'coverage[toml]>=5.0a4',  # Code coverage measurement for Python
         'pytest>=4.6.11',  # Our tests framework
-        'setuptools>=71.0.0',  # Needed as a dependency for some tests
     ],
     # Dependencies that are required to build documentation
     'docs': [

--- a/tox.ini
+++ b/tox.ini
@@ -164,8 +164,6 @@ deps =
     build
     twine
     check-wheel-contents
-commands_pre =
-    python -m pip install -U pip setuptools wheel
 commands =
     python -m build --outdir {envtmpdir}/build
     twine check {envtmpdir}/build/*


### PR DESCRIPTION
This guarantees that the project will always be built with a modern `setuptools`.

More importantly, it guarantees that the sdist can be built in modern isolated build environments, which no longer have `setuptools` by default.