### PR TITLE
Remove remaining Python 3.9 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ envlist =
     lint
     type
     manifest
-    py39-django{22,30,31,32,40,41,42}
     py310-django{32,40,41,42,50,51,52}
     py311-django{41,42,50,51,52}
     py312-django{42,50,51,52,60}


### PR DESCRIPTION
This was missed in the overlap between #627 and #629.