### PR TITLE
ci: allow release and hotfix PRs to target main

### DIFF
--- a/.github/workflows/change-pr-target.yml
+++ b/.github/workflows/change-pr-target.yml
@@ -13,8 +13,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           target: main
-          exclude: develop # Don't prevent going from develop -> main
+          # Allow integration, release, and hotfix branches to target main.
+          exclude: "develop /^[^:]+:(?:release|hotfix)\\/.+$/"
           change-to: develop
           comment: |
-            Your PR was set to target `main`, PRs should be target `develop`
+            Your PR was set to target `main`. Only `develop`, `release/*`,
+            and `hotfix/*` branches may target `main`.
             The base branch of this PR has been automatically changed to `develop`, please check that there are no merge conflicts.


### PR DESCRIPTION
## Summary

Allow `release/*` and `hotfix/*` branches, in addition to `develop`, to open pull requests directly against `main`.

## Context

The repository uses `develop` as its default branch. Since `pull_request_target` workflows are loaded from the default branch, this rule must be present on `develop` before release and hotfix PRs can remain targeted at `main`.

Other branches targeting `main` will continue to be automatically redirected to `develop`.
