### PR TITLE
Use casted dict keys for value casts

### DIFF
--- a/environ/environ.py
+++ b/environ/environ.py
@@ -591,20 +591,19 @@ class Env:
             key_cast = cast.get('key', str)
             value_cast = cast.get('value', str)
             value_cast_by_key = cast.get('cast', {})
-            value = dict(map(
-                lambda kv: (
-                    key_cast(kv[0]),
-                    cls.parse_value(
-                        kv[1],
-                        value_cast_by_key.get(kv[0], value_cast)
-                    )
-                ),
-                # Limit to a single split so values that themselves contain
-                # '=' (e.g. base64 padding, JWTs, query strings) are preserved.
-                # This matches the simple-dict path below which already uses
-                # ``split('=', 1)`` (cf. #565).
-                [val.split('=', 1) for val in value.split(';') if val]
-            ))
+            values = {}
+            for raw_key, raw_value in (
+                    # Limit to a single split so values that themselves contain
+                    # '=' (e.g. base64 padding, JWTs, query strings) are
+                    # preserved. This matches the simple-dict path below which
+                    # already uses ``split('=', 1)`` (cf. #565).
+                    val.split('=', 1) for val in value.split(';') if val):
+                key = key_cast(raw_key)
+                values[key] = cls.parse_value(
+                    raw_value,
+                    value_cast_by_key.get(key, value_cast)
+                )
+            value = values
         elif cast is dict:
             value = dict([v.split('=', 1) for v in value.split(',') if v])
         elif cast is list:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -379,6 +379,9 @@ class TestEnv:
             ('a=1;b=v=more',
              dict(value=str),
              {'a': '1', 'b': 'v=more'}),
+            ('1=True',
+             dict(key=int, value=str, cast={1: bool}),
+             {1: True}),
         ],
         ids=[
             'dict',
@@ -389,6 +392,7 @@ class TestEnv:
             'dict_int_cast',
             'dict_str_cast',
             'dict_value_contains_equal_sign',
+            'dict_cast_by_casted_key',
         ],
     )
     def test_dict_parsing(self, value, cast, expected):


### PR DESCRIPTION
## Summary

Use the casted dictionary key when applying per-key value casts in `Env.parse_value`.

When `cast` specifies both a key caster and per-key value casts, the output key has already been converted. Looking up `cast` overrides by the raw string key means typed keys such as `1` cannot match `cast={1: bool}`, so the value falls back to the default value cast.

## Validation

- Added a regression case for `dict(key=int, value=str, cast={1: bool})`
- Confirmed the new test failed before the implementation change with `{1: 'True'} != {1: True}`
- Ran `python -m pytest tests/test_env.py::TestEnv::test_dict_parsing -q` and confirmed 9 passed
- Ran `python -m pytest -q` and confirmed 474 passed