### PR TITLE
Fix Env.__contains__ ignoring the configured prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Changed
 
 Fixed
 +++++
+- Fixed ``Env.__contains__`` ignoring the configured ``prefix``, so membership
+  tests now agree with ``get_value()``
+  `#644 <https://github.com/joke2k/django-environ/issues/644>`_.
 - Improved type hint coverage and related lint issues
   `#546 <https://github.com/joke2k/django-environ/pull/546>`_.
 - Fixed typos in the FAQ page

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -287,7 +287,8 @@ class Env:
         )
 
     def __contains__(self, var):
-        return var in self.ENVIRON
+        # Mirror get_value(), which reads the prefixed name, so membership tests agree with lookups.
+        return f'{self.prefix}{var}' in self.ENVIRON
 
     def str(
             self,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -557,6 +557,12 @@ class TestEnv:
         self.env.prefix = 'PREFIX_'
         assert self.env('TEST') == 'foo'
 
+    def test_prefix_contains(self):
+        # Membership tests must honour the prefix, consistent with get_value().
+        self.env.prefix = 'PREFIX_'
+        assert 'TEST' in self.env
+        assert 'PREFIX_TEST' not in self.env
+
     def test_prefix_and_not_present_without_default(self):
         self.env.prefix = 'PREFIX_'
         with pytest.raises(ImproperlyConfigured) as excinfo:


### PR DESCRIPTION
Fixes #644.

`Env.get_value()` reads the prefixed name (`f'{self.prefix}{var}'`), but `Env.__contains__` checked the raw key, so `"DEBUG" in env` returned `False` even though `env("DEBUG")` resolved via `DJANGO_DEBUG`. Membership now honours the prefix, consistent with lookups. With no prefix set (the default `''`) behaviour is unchanged.

Added `test_prefix_contains` (fails on `main`, passes with the fix); full suite green (474 passed). Added a CHANGELOG entry under Fixed.
